### PR TITLE
Add mobile FAB navigation

### DIFF
--- a/fabs/mobile.html
+++ b/fabs/mobile.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Mobile Navigation</title>
+<link rel="stylesheet" href="https://use.fontawesome.com/releases/v6.5.0/css/all.css">
+<link rel="stylesheet" href="../css/min.css">
+<style>
+:root{--clr-primary:#00c4ff;--clr-accent:#ff3bdb;--clr-accent-dark:#e000be;}
+/* Copied from FABs in min.css and adapted for horizontal mobile nav */
+.mobile-nav{position:fixed;bottom:25px;right:15px;display:flex;align-items:center;gap:10px;z-index:1000;transition:width .3s;}
+.mobile-nav .nav-items{display:none;gap:10px;}
+.mobile-nav.open{width:90%;justify-content:flex-end;}
+.mobile-nav.open .nav-items{display:flex;flex-wrap:nowrap;}
+.nav-btn{width:44px;height:44px;border-radius:50%;border:none;background:var(--clr-primary);color:#fff;font-size:1.2rem;display:flex;align-items:center;justify-content:center;cursor:pointer;box-shadow:0 4px 12px #0005;}
+.nav-btn.main{background:var(--clr-accent);}
+.nav-btn.main.open{transform:rotate(135deg);}
+/* Services dropdown */
+.dropdown{position:relative;}
+.dropdown-menu{position:absolute;bottom:50px;right:0;background:#333;color:#fff;border-radius:8px;padding:6px 8px;display:none;flex-direction:column;gap:4px;font-size:.9rem;}
+.dropdown-menu a{color:#fff;text-decoration:none;padding:4px 6px;white-space:nowrap;}
+.dropdown.open .dropdown-menu{display:flex;}
+</style>
+</head>
+<body>
+<div id="mobileNav" class="mobile-nav">
+  <div class="nav-items">
+    <a href="../index.html" class="nav-btn" title="Home"><i class="fa fa-home"></i></a>
+    <div class="dropdown">
+      <button id="svcBtn" class="nav-btn" aria-expanded="false"><i class="fa fa-bars"></i></button>
+      <div class="dropdown-menu" id="svcMenu">
+        <a href="../mainnav/opera.html">Ops</a>
+        <a href="../mainnav/center.html">Center</a>
+        <a href="../mainnav/it.html">IT</a>
+        <a href="../mainnav/pros.html">Pros</a>
+      </div>
+    </div>
+    <button id="langBtn" class="nav-btn">ES</button>
+    <button id="themeBtn" class="nav-btn">Dark</button>
+    <a href="chatbot.html" class="nav-btn" title="Chatbot"><i class="fa fa-comment"></i></a>
+    <a href="joinus.html" class="nav-btn" title="Join Us"><i class="fa fa-user-plus"></i></a>
+    <a href="contactus.html" class="nav-btn" title="Contact Us"><i class="fa fa-envelope"></i></a>
+  </div>
+  <button id="toggleNav" class="nav-btn main" aria-label="Menu"><i class="fa fa-plus"></i></button>
+</div>
+<script>
+const mobileNav = document.getElementById('mobileNav');
+const toggleNav = document.getElementById('toggleNav');
+const langBtn = document.getElementById('langBtn');
+const themeBtn = document.getElementById('themeBtn');
+const svcBtn = document.getElementById('svcBtn');
+const svcMenu = document.getElementById('svcMenu');
+
+let lang='en';
+let dark=false;
+
+toggleNav.onclick = ()=>{
+  mobileNav.classList.toggle('open');
+  toggleNav.classList.toggle('open');
+};
+
+svcBtn.onclick = () => {
+  svcBtn.parentElement.classList.toggle('open');
+  const expanded = svcBtn.getAttribute('aria-expanded') === 'true';
+  svcBtn.setAttribute('aria-expanded', !expanded);
+};
+
+langBtn.onclick = () => {
+  lang = lang==='en'?'es':'en';
+  langBtn.textContent = lang==='en'?'ES':'EN';
+  document.documentElement.lang = lang;
+};
+
+themeBtn.onclick = () => {
+  dark = !dark;
+  document.body.classList.toggle('dark', dark);
+  themeBtn.textContent = dark?'Light':'Dark';
+};
+</script>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- create `mobile.html` in `fabs/`
- add responsive floating navigation bar that expands horizontally
- copy FAB styles and adapt for mobile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68877e681040832b87c05554a767d0ee