### PR TITLE
Add floating FABs snippet and integrate across site

### DIFF
--- a/fabs/fabs.html
+++ b/fabs/fabs.html
@@ -1,0 +1,36 @@
+<!-- Floating Action Buttons snippet -->
+<link rel="stylesheet" href="../css/style.css">
+<link rel="stylesheet" href="https://use.fontawesome.com/releases/v6.5.0/css/all.css">
+<style>
+#fab-container {
+  position: fixed;
+  bottom: 15px;
+  right: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  z-index: 2000;
+}
+#fab-container a {
+  background: var(--clr-accent, #ff3bdc);
+  color: #fff;
+  width: 48px;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+  border-radius: 50%;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+  font-size: 1.2rem;
+}
+#fab-container a:hover {
+  background: var(--clr-accent-dark, #e000be);
+}
+</style>
+<div id="fab-container">
+  <a href="../fabs/chatbot.html" title="Chatbot"><i class="fa fa-comment"></i></a>
+  <a href="../fabs/contactus.html" title="Contact Us"><i class="fa fa-envelope"></i></a>
+  <a href="../fabs/joinus.html" title="Join Us"><i class="fa fa-user-plus"></i></a>
+  <a href="../fabs/mobile.html" title="Menu"><i class="fa fa-bars"></i></a>
+</div>

--- a/index.html
+++ b/index.html
@@ -286,5 +286,11 @@
       };
     }
   </script>
+  <script>
+    fetch('fabs/fabs.html')
+      .then(r => r.text())
+      .then(h => { document.body.insertAdjacentHTML('beforeend', h); })
+      .catch(err => console.error('FABs load error', err));
+  </script>
 </body>
 </html>

--- a/mainnav/center.html
+++ b/mainnav/center.html
@@ -472,5 +472,11 @@
       setTheme(isDark);
     })();
   </script>
+  <script>
+    fetch('../fabs/fabs.html')
+      .then(r => r.text())
+      .then(h => { document.body.insertAdjacentHTML('beforeend', h); })
+      .catch(err => console.error('FABs load error', err));
+  </script>
 </body>
 </html>

--- a/mainnav/it.html
+++ b/mainnav/it.html
@@ -464,5 +464,11 @@
       setTheme(isDark);
     })();
   </script>
+  <script>
+    fetch('../fabs/fabs.html')
+      .then(r => r.text())
+      .then(h => { document.body.insertAdjacentHTML('beforeend', h); })
+      .catch(err => console.error('FABs load error', err));
+  </script>
 </body>
 </html>

--- a/mainnav/opera.html
+++ b/mainnav/opera.html
@@ -571,5 +571,11 @@
       setTheme(isDark);
     })();
   </script>
+  <script>
+    fetch('../fabs/fabs.html')
+      .then(r => r.text())
+      .then(h => { document.body.insertAdjacentHTML('beforeend', h); })
+      .catch(err => console.error('FABs load error', err));
+  </script>
 </body>
 </html>

--- a/mainnav/pros.html
+++ b/mainnav/pros.html
@@ -446,5 +446,11 @@
       setTheme(isDark);
     })();
   </script>
+  <script>
+    fetch('../fabs/fabs.html')
+      .then(r => r.text())
+      .then(h => { document.body.insertAdjacentHTML('beforeend', h); })
+      .catch(err => console.error('FABs load error', err));
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a `fabs.html` snippet with floating action buttons for Chatbot, Contact Us, Join Us and Mobile menu
- load the snippet on the main index and all main navigation pages

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68878d190618832ba73d6ec7e4597e79