### PR TITLE
Fix <select> options in contact page

### DIFF
--- a/fabs/contactus.html
+++ b/fabs/contactus.html
@@ -120,11 +120,11 @@
         <label for="interest">What are you interested about?</label>
         <select id="interest" required>
           <option value="" disabled selected>Select an option</option>
-    <a href="../index.html" data-en="Home" data-es="Inicio">Home</a>
-    <a href="opera.html" data-en="Business Operations" data-es="Gestion">Business Operations</a>
-    <a href="center.html" data-en="Contact Center" data-es="Centro de Contacto">Contact Center</a>
-    <a href="it.html" data-en="IT Support" data-es="Soporte IT">IT Support</a>
-    <a href="pros.html" data-en="Professionals" data-es="Profesionales">Professionals</a>
+          <option>Home</option>
+          <option>Business Operations</option>
+          <option>Contact Center</option>
+          <option>IT Support</option>
+          <option>Professionals</option>
         </select>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- remove stray anchor elements from `interest` dropdown
- restore proper `<option>` tags for contact page form

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887fbfb0f5c832b944f788c4b6940e0