### PR TITLE
Persist theme choice across pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,7 +212,8 @@
       }
     };
     let lang = "en";
-    let theme = "light";
+    let theme = localStorage.getItem('theme') || "light";
+    document.body.classList.toggle('dark', theme === 'dark');
     function renderCards() {
       Object.entries({ops:'ops',cc:'cc',it:'it',pro:'pro'}).forEach(([id, key]) => {
         let c = svc[key][lang];

--- a/js/main.js
+++ b/js/main.js
@@ -1,17 +1,21 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const themeToggle = document.getElementById('theme-toggle');
-  const langToggle = document.getElementById('lang-toggle');
+  const themeToggle = document.getElementById('theme-toggle') || document.getElementById('btn-theme');
+  const langToggle = document.getElementById('lang-toggle') || document.getElementById('btn-lang');
 
-  themeToggle.addEventListener('click', () => {
-    document.body.classList.toggle('dark');
-    theme = document.body.classList.contains('dark') ? 'dark' : 'light';
-    themeToggle.textContent = theme === 'dark' ? 'Light' : 'Dark';
+  const savedTheme = localStorage.getItem('theme') || 'light';
+  document.body.classList.toggle('dark', savedTheme === 'dark');
+  if (themeToggle) themeToggle.textContent = savedTheme === 'dark' ? 'Light' : 'Dark';
+
+  themeToggle && themeToggle.addEventListener('click', () => {
+    const isDark = document.body.classList.toggle('dark');
+    localStorage.setItem('theme', isDark ? 'dark' : 'light');
+    themeToggle.textContent = isDark ? 'Light' : 'Dark';
   });
 
-  langToggle.addEventListener('click', () => {
+  langToggle && langToggle.addEventListener('click', () => {
     lang = lang === 'en' ? 'es' : 'en';
-    langToggle.textContent = lang === 'en' ? 'ES' : 'EN';
-    renderCards();
+    if (langToggle) langToggle.textContent = lang === 'en' ? 'ES' : 'EN';
+    if (typeof renderCards === 'function') renderCards();
     updateNav();
   });
 

--- a/mainnav/center.html
+++ b/mainnav/center.html
@@ -422,7 +422,7 @@
 
       // Default states
       let currentLang = 'en';
-      let isDark = true;
+      let isDark = (localStorage.getItem('theme') || 'light') === 'dark';
 
       function setLanguage(lang) {
         currentLang = lang;
@@ -467,6 +467,7 @@
           btnTheme.textContent = 'Light Mode';
           btnTheme.setAttribute('aria-pressed', 'true');
         }
+        localStorage.setItem('theme', darkMode ? 'dark' : 'light');
       }
 
       function toggleTheme() {

--- a/mainnav/it.html
+++ b/mainnav/it.html
@@ -354,7 +354,7 @@
       const html = document.documentElement;
       const body = document.body;
       let currentLang = 'en';
-      let isDark = true;
+      let isDark = (localStorage.getItem('theme') || 'light') === 'dark';
       function setLanguage(lang) {
         currentLang = lang;
         html.lang = lang;
@@ -392,6 +392,7 @@
           btnTheme.textContent = 'Light Mode';
           btnTheme.setAttribute('aria-pressed', 'true');
         }
+        localStorage.setItem('theme', darkMode ? 'dark' : 'light');
       }
       function toggleTheme() {
         setTheme(!isDark);

--- a/mainnav/opera.html
+++ b/mainnav/opera.html
@@ -510,7 +510,7 @@
       const body = document.body;
       // Default language and theme
       let currentLang = 'en';
-      let isDark = true;
+      let isDark = (localStorage.getItem('theme') || 'light') === 'dark';
       function setLanguage(lang) {
         currentLang = lang;
         html.lang = lang;
@@ -553,6 +553,7 @@
           btnTheme.textContent = 'Light Mode';
           btnTheme.setAttribute('aria-pressed', 'true');
         }
+        localStorage.setItem('theme', darkMode ? 'dark' : 'light');
       }
       function toggleTheme() {
         setTheme(!isDark);

--- a/mainnav/pros.html
+++ b/mainnav/pros.html
@@ -393,7 +393,7 @@
 
       // Default states
       let currentLang = 'en';
-      let isDark = true;
+      let isDark = (localStorage.getItem('theme') || 'light') === 'dark';
 
       function setLanguage(lang) {
         currentLang = lang;
@@ -438,6 +438,7 @@
           btnTheme.textContent = 'Light Mode';
           btnTheme.setAttribute('aria-pressed', 'true');
         }
+        localStorage.setItem('theme', darkMode ? 'dark' : 'light');
       }
 
       function toggleTheme() {


### PR DESCRIPTION
## Summary
- read saved theme from `localStorage` and apply on page load
- store updated theme when toggled
- initialize theme from storage on all nav pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68897d483ce8832b86d7e982ba1b76f2