### PR TITLE
Fix modal centering and navigation menu styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -156,7 +156,7 @@
       left: 0; top: 0; right: 0; bottom: 0;
       background: rgba(44,26,73,0.31);
       display: flex;
-      align-items: flex-start;
+      align-items: center;
       justify-content: center;
     }
     .ops-modal, .modal-content, #chatbot-container {

--- a/index.html
+++ b/index.html
@@ -17,11 +17,11 @@
   <nav class="ops-nav" aria-label="OPS Navigation">
     <span class="ops-logo">OPS</span>
     <div class="nav-links">
-    <a href="index.html" data-en="Home" data-es="Inicio">Home</a>
-    <a href="mainnav/opera.html" data-en="Business Operations" data-es="Gestion">Business Operations</a>
-    <a href="mainnav/center.html" data-en="Contact Center" data-es="Centro de Contacto">Contact Center</a>
-    <a href="mainnav/it.html" data-en="IT Support" data-es="Soporte IT">IT Support</a>
-    <a href="mainnav/pros.html" data-en="Professionals" data-es="Profesionales">Professionals</a>
+    <a href="index.html" class="nav-link" data-en="Home" data-es="Inicio">Home</a>
+    <a href="mainnav/opera.html" class="nav-link" data-en="Business Operations" data-es="Gestion">Business Operations</a>
+    <a href="mainnav/center.html" class="nav-link" data-en="Contact Center" data-es="Centro de Contacto">Contact Center</a>
+    <a href="mainnav/it.html" class="nav-link" data-en="IT Support" data-es="Soporte IT">IT Support</a>
+    <a href="mainnav/pros.html" class="nav-link" data-en="Professionals" data-es="Profesionales">Professionals</a>
     </div>
     <div class="toggles">
       <button class="toggle-btn" id="lang-toggle">ES</button>
@@ -265,7 +265,6 @@
       root.innerHTML = '';
       root.appendChild(m);
       const modal = m.querySelector('.modal');
-      centerModal(modal);
       modal.focus();
       // Event handlers
       function close() { root.innerHTML = ''; }
@@ -298,13 +297,6 @@
       };
     }
 
-    function centerModal(modal) {
-      const left = (window.innerWidth - modal.offsetWidth) / 2;
-      const top = Math.max((window.innerHeight - modal.offsetHeight) / 2, 20);
-      modal.style.left = `${left}px`;
-      modal.style.top = `${top}px`;
-      modal.style.transform = 'none';
-    }
   </script>
   <script src="js/load-fabs.js"></script>
   <script src="js/modals.js"></script>

--- a/js/main.js
+++ b/js/main.js
@@ -56,7 +56,6 @@ function openContactModal() {
       root.innerHTML = '';
       root.appendChild(m);
       const modal = m.querySelector('.ops-modal');
-      centerModal(modal);
       modal.focus();
       function close() { root.innerHTML = ''; }
       m.onclick = e => (e.target === m ? close() : 0);
@@ -79,11 +78,4 @@ function openContactModal() {
     .catch(err => console.error('Contact modal load error', err));
 }
 
-function centerModal(modal) {
-  const left = (window.innerWidth - modal.offsetWidth) / 2;
-  const top = Math.max((window.innerHeight - modal.offsetHeight) / 2, 20);
-  modal.style.left = `${left}px`;
-  modal.style.top = `${top}px`;
-  modal.style.transform = 'none';
-}
 

--- a/js/modals.js
+++ b/js/modals.js
@@ -79,7 +79,6 @@ function openJoinModal() {
       root.innerHTML = '';
       root.appendChild(m);
       const modal = m.querySelector('.ops-modal');
-      centerModal(modal);
       modal.focus();
       function close() { root.innerHTML = ''; }
       m.onclick = e => (e.target === m ? close() : 0);


### PR DESCRIPTION
- Updated the CSS to correctly center modals on the screen by changing `align-items` to `center` for the modal backdrop.
- Removed the javascript `centerModal` function which was conflicting with the CSS.
- Added the `nav-link` class to the main navigation links on the index page to apply the correct CSS styling.