### PR TITLE
Update subpage script references

### DIFF
--- a/mainnav/center.html
+++ b/mainnav/center.html
@@ -506,15 +506,9 @@
       setTheme(isDark);
     })();
   </script>
-  <script>
-    fetch('fabs/fabs.html')
-      .then(r => r.text())
-      .then(h => { document.body.insertAdjacentHTML('beforeend', h); })
-      .catch(err => console.error('FABs load error', err));
-  </script>
   <div id="modal-root"></div>
-  <script src="js/load-fabs.js"></script>
-  <script src="js/modals.js"></script>
-  <script src="js/main.js"></script>
+  <script src="../js/load-fabs.js"></script>
+  <script src="../js/modals.js"></script>
+  <script src="../js/main.js"></script>
 </body>
 </html>

--- a/mainnav/it.html
+++ b/mainnav/it.html
@@ -428,15 +428,9 @@
       setTheme(isDark);
     })();
   </script>
- <script>
-    fetch('fabs/fabs.html')
-      .then(r => r.text())
-      .then(h => { document.body.insertAdjacentHTML('beforeend', h); })
-      .catch(err => console.error('FABs load error', err));
-  </script>
   <div id="modal-root"></div>
-  <script src="js/load-fabs.js"></script>
-  <script src="js/modals.js"></script>
-  <script src="js/main.js"></script>
+  <script src="../js/load-fabs.js"></script>
+  <script src="../js/modals.js"></script>
+  <script src="../js/main.js"></script>
 </body>
 </html>

--- a/mainnav/opera.html
+++ b/mainnav/opera.html
@@ -590,15 +590,9 @@
       setTheme(isDark);
     })();
   </script>
- <script>
-    fetch('fabs/fabs.html')
-      .then(r => r.text())
-      .then(h => { document.body.insertAdjacentHTML('beforeend', h); })
-      .catch(err => console.error('FABs load error', err));
-  </script>
   <div id="modal-root"></div>
-  <script src="js/load-fabs.js"></script>
-  <script src="js/modals.js"></script>
-  <script src="js/main.js"></script>
+  <script src="../js/load-fabs.js"></script>
+  <script src="../js/modals.js"></script>
+  <script src="../js/main.js"></script>
 </body>
 </html>

--- a/mainnav/pros.html
+++ b/mainnav/pros.html
@@ -478,15 +478,9 @@
       setTheme(isDark);
     })();
   </script>
- <script>
-    fetch('fabs/fabs.html')
-      .then(r => r.text())
-      .then(h => { document.body.insertAdjacentHTML('beforeend', h); })
-      .catch(err => console.error('FABs load error', err));
-  </script>
   <div id="modal-root"></div>
-  <script src="js/load-fabs.js"></script>
-  <script src="js/modals.js"></script>
-  <script src="js/main.js"></script>
+  <script src="../js/load-fabs.js"></script>
+  <script src="../js/modals.js"></script>
+  <script src="../js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load shared scripts from parent directory for subpages
- remove redundant inline FAB loader so `load-fabs.js` handles it

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a67b0d47c832b8018b342965a0492