### PR TITLE
Center modals and preserve drag

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -177,9 +177,9 @@
       box-shadow: 0 6px 60px #5e24bb25, 0 0 0 2px #fff1;
       padding: 2.1rem 2.2rem 1.3rem 2.2rem;
       position: absolute;
-      left: 0;
-      top: 0;
-      transform: none;
+      left: 50%;
+      top: 50%;
+      transform: translate(-50%, -50%);
       transition: box-shadow .17s;
       cursor: default;
       z-index: 2222;

--- a/index.html
+++ b/index.html
@@ -107,21 +107,34 @@
       modal.querySelector('#join-us').onclick = ()=>{ openJoinModal(); close(); };
     }
     function makeDraggable(elem, dragHandle) {
-      let isDown = false, startX=0, startY=0;
+      let isDown = false, startX = 0, startY = 0;
       let header = dragHandle || elem;
       header.style.cursor = 'move';
       header.onmousedown = function(e) {
         isDown = true;
         elem.classList.add('dragging');
-        startX = e.clientX - (parseInt(elem.style.left)||window.innerWidth/2);
-        startY = e.clientY - (parseInt(elem.style.top)||window.innerHeight/4);
+        function toPixels(val, total, def) {
+          if (!val) return def;
+          if (String(val).includes('%')) return total * parseFloat(val) / 100;
+          const num = parseFloat(val);
+          return isNaN(num) ? def : num;
+        }
+        const leftPx = toPixels(elem.style.left, window.innerWidth, window.innerWidth/2);
+        const topPx = toPixels(elem.style.top, window.innerHeight, window.innerHeight/4);
+        startX = e.clientX - leftPx;
+        startY = e.clientY - topPx;
         document.onmousemove = function(e) {
           if (!isDown) return;
-          elem.style.left = `${e.clientX-startX}px`;
-          elem.style.top = `${e.clientY-startY}px`;
+          elem.style.left = `${e.clientX - startX}px`;
+          elem.style.top = `${e.clientY - startY}px`;
           elem.style.transform = 'translate(0, 0)';
         };
-        document.onmouseup = function(){ isDown=false; elem.classList.remove('dragging'); document.onmousemove=null; document.onmouseup=null; };
+        document.onmouseup = function() {
+          isDown = false;
+          elem.classList.remove('dragging');
+          document.onmousemove = null;
+          document.onmouseup = null;
+        };
         return false;
       };
     }


### PR DESCRIPTION
## Summary
- center modal windows so they appear in middle of viewport
- update drag handler to correctly calculate starting position when left/top use percentages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b51ee71e0832b97e9b6f1ba33da15