### PR TITLE
Close modals on form submit

### DIFF
--- a/fabs/contactus.html
+++ b/fabs/contactus.html
@@ -167,6 +167,7 @@
       }
       alert('Contact form submitted!');
       contactForm.reset();
+      window.dispatchEvent(new CustomEvent('modal-close'));
     });
   });
   </script>

--- a/fabs/joinus.html
+++ b/fabs/joinus.html
@@ -373,6 +373,7 @@
         const inputsContainer = section.querySelector('.inputs');
         inputsContainer.innerHTML = '';
       });
+      window.dispatchEvent(new CustomEvent('modal-close'));
     });
   });
 </script>

--- a/js/modals.js
+++ b/js/modals.js
@@ -59,6 +59,8 @@ function openContactModal() {
       const modal = m.querySelector('.ops-modal');
       modal.focus();
       function close() { root.innerHTML = ''; }
+      const handleClose = () => { close(); };
+      window.addEventListener('modal-close', handleClose, { once: true });
       m.onclick = e => (e.target === m ? close() : 0);
       modal.querySelector('.modal-x').onclick = close;
       document.addEventListener('keydown', function esc(e) { if (e.key === 'Escape') { close(); document.removeEventListener('keydown', esc); } }, { once: true });
@@ -111,6 +113,8 @@ function openJoinModal() {
       const modal = m.querySelector('.ops-modal');
       modal.focus();
       function close() { root.innerHTML = ''; }
+      const handleClose = () => { close(); };
+      window.addEventListener('modal-close', handleClose, { once: true });
       m.onclick = e => (e.target === m ? close() : 0);
       modal.querySelector('.modal-x').onclick = close;
       document.addEventListener('keydown', function esc(e) { if (e.key === 'Escape') { close(); document.removeEventListener('keydown', esc); } }, { once: true });
@@ -124,6 +128,7 @@ function openJoinModal() {
           }
           alert('Join form submitted!');
           form.reset();
+          close();
         });
       }
       if (typeof makeDraggable === 'function') makeDraggable(modal);


### PR DESCRIPTION
## Summary
- add `modal-close` events in contact/join forms
- listen for those events in the modal logic
- close the join modal after successful submission

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_688b5504e554832ba0df5a9f79c226b9