### PR TITLE
Add responsive page wrapper

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -342,6 +342,12 @@
       #chat-log::-webkit-scrollbar {
           display: none; /* Chrome, Safari, Opera */
       }
+  .page-content {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
     }
 
 @media (max-width: 480px) {

--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
       <i class="fa-solid fa-bars"></i>
     </button>
   </nav>
+<main class="page-content">
   <!-- CARDS GRID -->
   <div class="grid-container">
     <div class="card" id="card-ops" role="button" tabindex="0"></div>
@@ -39,6 +40,7 @@
     <div class="card" id="card-pro" role="button" tabindex="0"></div>
   </div>
   <div id="modal-root"></div>
+</main>
 
   <footer>
     © 2025 OPS Online Support

--- a/mainnav/center.html
+++ b/mainnav/center.html
@@ -331,6 +331,7 @@
     <button id="btn-lang" aria-label="Toggle language" aria-pressed="false">EN</button>
     <button id="btn-theme" aria-label="Toggle dark/light theme" aria-pressed="false">Dark Mode</button>
   </div>
+<main class="page-content">
 
   <!-- Header -->
   <header>
@@ -448,6 +449,7 @@
     </form>
   </section>
 
+</main>
   <script>
     (function() {
       const btnLang = document.getElementById('btn-lang');

--- a/mainnav/it.html
+++ b/mainnav/it.html
@@ -323,6 +323,7 @@
     <button id="btn-lang" aria-label="Toggle language" aria-pressed="false">EN</button>
     <button id="btn-theme" aria-label="Toggle dark/light theme" aria-pressed="false">Dark Mode</button>
   </div>
+<main class="page-content">
   <!-- Header -->
   <header>
     <h1 data-en="Keep Your Systems Secure and Stable" data-es="Mantenga Sus Sistemas Seguros y Estables">
@@ -383,6 +384,7 @@
       </button>
     </form>
   </section>
+</main>
   <script>
     (function() {
       const btnLang = document.getElementById('btn-lang');

--- a/mainnav/opera.html
+++ b/mainnav/opera.html
@@ -449,6 +449,7 @@
     <button id="btn-lang" aria-label="Toggle language" aria-pressed="false">EN</button>
     <button id="btn-theme" aria-label="Toggle dark/light theme" aria-pressed="false">Dark Mode</button>
   </div>
+<main class="page-content">
   <!-- Header -->
   <header>
     <h1 data-en="Streamline Your Business Operations" data-es="Optimice Sus Operaciones Empresariales">
@@ -462,7 +463,6 @@
       Get Started
     </a>
   </header>
-  <main>
     <!-- Left Info Card -->
     <div class="info-cards">
       <h2 data-en="Optimize Your Business Operations" data-es="Optimice Sus Operaciones Empresariales">
@@ -507,7 +507,6 @@
         </div>
       </div>
     </div>
-  </main>
   <!-- Contact Form -->
    <section id="form">
     <h2 id="opera-form-title" data-en="See What We Can Do for You" data-es="Vea Lo Que Podemos Hacer por Usted">See What We Can Do for You</h2>
@@ -538,6 +537,7 @@
       </button>
     </form>
   </section>
+</main>
     <script>
     (function() {
       const btnLang = document.getElementById('btn-lang');

--- a/mainnav/pros.html
+++ b/mainnav/pros.html
@@ -329,6 +329,7 @@
     <button id="btn-lang" aria-label="Toggle language" aria-pressed="false">EN</button>
     <button id="btn-theme" aria-label="Toggle dark/light theme" aria-pressed="false">Dark Mode</button>
   </div>
+<main class="page-content">
 
   <!-- Header -->
   <header>
@@ -419,6 +420,7 @@
       </button>
     </form>
   </section>
+</main>
 
   <script>
     (function() {


### PR DESCRIPTION
## Summary
- center content vertically on small screens via `.page-content` media style
- wrap main content of each page in `<main class="page-content">`

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_688b5a42a9a0832bbf3c8dd2e51b1a06