### PR TITLE
Fix modal base path detection

### DIFF
--- a/js/modals.js
+++ b/js/modals.js
@@ -40,7 +40,7 @@ if (themeBtn) {
 
 // --- CONTACT US MODAL ---
 function openContactModal() {
-  const base = window.location.pathname.includes('/mainnav/') ? '..' : '.';
+  const base = location.pathname.includes('/mainnav/') || location.pathname.includes('/fabs/') ? '..' : '.';
   fetch(`${base}/fabs/contactus.html`)
     .then(r => r.text())
     .then(html => {
@@ -69,7 +69,7 @@ function openContactModal() {
 
 // --- CHATBOT MODAL ---
 function openChatbotModal() {
-  const base = window.location.pathname.includes('/mainnav/') ? '..' : '.';
+  const base = location.pathname.includes('/mainnav/') || location.pathname.includes('/fabs/') ? '..' : '.';
   fetch(`${base}/fabs/chatbot.html`)
     .then(r => r.text())
     .then(html => {
@@ -92,7 +92,7 @@ function openChatbotModal() {
 
 // --- JOIN US MODAL ---
 function openJoinModal() {
-  const base = window.location.pathname.includes('/mainnav/') ? '..' : '.';
+  const base = location.pathname.includes('/mainnav/') || location.pathname.includes('/fabs/') ? '..' : '.';
   fetch(`${base}/fabs/joinus.html`)
     .then(r => r.text())
     .then(html => {


### PR DESCRIPTION
## Summary
- detect `/fabs/` or `/mainnav/` path segments when loading modal HTML so they work from nested pages

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_688b607ae878832ba20976a533e71bcd