### PR TITLE
Extract inline init scripts to external file

### DIFF
--- a/js/page-init.js
+++ b/js/page-init.js
@@ -1,0 +1,61 @@
+(function() {
+  const btnLang = document.getElementById('btn-lang');
+  const btnTheme = document.getElementById('btn-theme');
+  const html = document.documentElement;
+  const body = document.body;
+
+  let currentLang = 'en';
+  let isDark = (localStorage.getItem('theme') || 'light') === 'dark';
+
+  function setLanguage(lang) {
+    currentLang = lang;
+    html.lang = lang;
+    const titleTag = document.querySelector('title');
+    document.title = titleTag.getAttribute('data-' + lang);
+    document.querySelectorAll('[data-en]').forEach(el => {
+      const text = el.getAttribute('data-' + lang);
+      if (!text) return;
+      if (el.tagName.toLowerCase() === 'input') {
+        el.placeholder = text;
+      } else if (el.tagName.toLowerCase() === 'img') {
+        el.alt = text;
+      } else {
+        el.textContent = text;
+      }
+    });
+    document.querySelectorAll('nav a').forEach(a => {
+      const text = a.getAttribute('data-' + lang);
+      if (text) a.textContent = text;
+    });
+    btnLang.textContent = lang.toUpperCase();
+    btnLang.setAttribute('aria-pressed', lang === 'es');
+  }
+
+  function toggleLanguage() {
+    setLanguage(currentLang === 'en' ? 'es' : 'en');
+  }
+
+  function setTheme(darkMode) {
+    isDark = darkMode;
+    if (darkMode) {
+      body.classList.remove('light');
+      btnTheme.textContent = 'Dark Mode';
+      btnTheme.setAttribute('aria-pressed', 'false');
+    } else {
+      body.classList.add('light');
+      btnTheme.textContent = 'Light Mode';
+      btnTheme.setAttribute('aria-pressed', 'true');
+    }
+    localStorage.setItem('theme', darkMode ? 'dark' : 'light');
+  }
+
+  function toggleTheme() {
+    setTheme(!isDark);
+  }
+
+  if (btnLang) btnLang.addEventListener('click', toggleLanguage);
+  if (btnTheme) btnTheme.addEventListener('click', toggleTheme);
+
+  setLanguage(currentLang);
+  setTheme(isDark);
+})();

--- a/mainnav/center.html
+++ b/mainnav/center.html
@@ -448,75 +448,7 @@
     </form>
   </section>
 
-  <script>
-    (function() {
-      const btnLang = document.getElementById('btn-lang');
-      const btnTheme = document.getElementById('btn-theme');
-      const html = document.documentElement;
-      const body = document.body;
-
-      // Default states
-      let currentLang = 'en';
-      let isDark = (localStorage.getItem('theme') || 'light') === 'dark';
-
-      function setLanguage(lang) {
-        currentLang = lang;
-        html.lang = lang;
-        // Update <title>
-        const titleTag = document.querySelector('title');
-        document.title = titleTag.getAttribute('data-' + lang);
-        // Update all translatable elements
-        document.querySelectorAll('[data-en]').forEach(el => {
-          const text = el.getAttribute('data-' + lang);
-          if (!text) return;
-          if (el.tagName.toLowerCase() === 'input') {
-            el.placeholder = text;
-          } else if (el.tagName.toLowerCase() === 'img') {
-            el.alt = text;
-          } else {
-            el.textContent = text;
-          }
-        });
-        // Update nav links separately for better screen reader experience
-        document.querySelectorAll('nav a').forEach(a => {
-          const text = a.getAttribute('data-' + lang);
-          if (text) a.textContent = text;
-        });
-        // Update toggle language button label and ARIA
-        btnLang.textContent = lang.toUpperCase();
-        btnLang.setAttribute('aria-pressed', lang === 'es');
-      }
-
-      function toggleLanguage() {
-        setLanguage(currentLang === 'en' ? 'es' : 'en');
-      }
-
-      function setTheme(darkMode) {
-        isDark = darkMode;
-        if (darkMode) {
-          body.classList.remove('light');
-          btnTheme.textContent = 'Dark Mode';
-          btnTheme.setAttribute('aria-pressed', 'false');
-        } else {
-          body.classList.add('light');
-          btnTheme.textContent = 'Light Mode';
-          btnTheme.setAttribute('aria-pressed', 'true');
-        }
-        localStorage.setItem('theme', darkMode ? 'dark' : 'light');
-      }
-
-      function toggleTheme() {
-        setTheme(!isDark);
-      }
-
-      btnLang.addEventListener('click', toggleLanguage);
-      btnTheme.addEventListener('click', toggleTheme);
-
-      // Initialize default
-      setLanguage(currentLang);
-      setTheme(isDark);
-    })();
-  </script>
+  <script src="../js/page-init.js"></script>
   <div id="modal-root"></div>
   <script src="../js/load-fabs.js"></script>
   <script src="../js/modals.js"></script>

--- a/mainnav/it.html
+++ b/mainnav/it.html
@@ -383,62 +383,7 @@
       </button>
     </form>
   </section>
-  <script>
-    (function() {
-      const btnLang = document.getElementById('btn-lang');
-      const btnTheme = document.getElementById('btn-theme');
-      const html = document.documentElement;
-      const body = document.body;
-      let currentLang = 'en';
-      let isDark = (localStorage.getItem('theme') || 'light') === 'dark';
-      function setLanguage(lang) {
-        currentLang = lang;
-        html.lang = lang;
-        const titleTag = document.querySelector('title');
-        document.title = titleTag.getAttribute('data-' + lang);
-        document.querySelectorAll('[data-en]').forEach(el => {
-          const text = el.getAttribute('data-' + lang);
-          if (!text) return;
-          if (el.tagName.toLowerCase() === 'input') {
-            el.placeholder = text;
-          } else if (el.tagName.toLowerCase() === 'img') {
-            el.alt = text;
-          } else {
-            el.textContent = text;
-          }
-        });
-        document.querySelectorAll('nav a').forEach(a => {
-          const text = a.getAttribute('data-' + lang);
-          if (text) a.textContent = text;
-        });
-        btnLang.textContent = lang.toUpperCase();
-        btnLang.setAttribute('aria-pressed', lang === 'es');
-      }
-      function toggleLanguage() {
-        setLanguage(currentLang === 'en' ? 'es' : 'en');
-      }
-      function setTheme(darkMode) {
-        isDark = darkMode;
-        if (darkMode) {
-          body.classList.remove('light');
-          btnTheme.textContent = 'Dark Mode';
-          btnTheme.setAttribute('aria-pressed', 'false');
-        } else {
-          body.classList.add('light');
-          btnTheme.textContent = 'Light Mode';
-          btnTheme.setAttribute('aria-pressed', 'true');
-        }
-        localStorage.setItem('theme', darkMode ? 'dark' : 'light');
-      }
-      function toggleTheme() {
-        setTheme(!isDark);
-      }
-      btnLang.addEventListener('click', toggleLanguage);
-      btnTheme.addEventListener('click', toggleTheme);
-      setLanguage(currentLang);
-      setTheme(isDark);
-    })();
-  </script>
+  <script src="../js/page-init.js"></script>
   <div id="modal-root"></div>
   <script src="../js/load-fabs.js"></script>
   <script src="../js/modals.js"></script>

--- a/mainnav/opera.html
+++ b/mainnav/opera.html
@@ -538,69 +538,7 @@
       </button>
     </form>
   </section>
-    <script>
-    (function() {
-      const btnLang = document.getElementById('btn-lang');
-      const btnTheme = document.getElementById('btn-theme');
-      const html = document.documentElement;
-      const body = document.body;
-      // Default language and theme
-      let currentLang = 'en';
-      let isDark = (localStorage.getItem('theme') || 'light') === 'dark';
-      function setLanguage(lang) {
-        currentLang = lang;
-        html.lang = lang;
-        // Update title
-        const titleTag = document.querySelector('title');
-        document.title = titleTag.getAttribute('data-' + lang);
-        // Update all translatable elements
-        document.querySelectorAll('[data-en]').forEach(el => {
-          const text = el.getAttribute('data-' + lang);
-          if (!text) return;
-          if (el.tagName.toLowerCase() === 'input') {
-            el.placeholder = text;
-          } else if (el.tagName.toLowerCase() === 'img') {
-            el.alt = text;
-          } else {
-            el.textContent = text;
-          }
-        });
-        // Update nav links specifically (for better accessibility)
-        document.querySelectorAll('nav a').forEach(a => {
-          const text = a.getAttribute('data-' + lang);
-          if (text) a.textContent = text;
-        });
-        // Update toggle language button label
-        btnLang.textContent = lang.toUpperCase();
-        btnLang.setAttribute('aria-pressed', lang === 'es');
-      }
-      function toggleLanguage() {
-        const newLang = currentLang === 'en' ? 'es' : 'en';
-        setLanguage(newLang);
-      }
-      function setTheme(darkMode) {
-        isDark = darkMode;
-        if (darkMode) {
-          body.classList.remove('light');
-          btnTheme.textContent = 'Dark Mode';
-          btnTheme.setAttribute('aria-pressed', 'false');
-        } else {
-          body.classList.add('light');
-          btnTheme.textContent = 'Light Mode';
-          btnTheme.setAttribute('aria-pressed', 'true');
-        }
-        localStorage.setItem('theme', darkMode ? 'dark' : 'light');
-      }
-      function toggleTheme() {
-        setTheme(!isDark);
-      }
-      btnLang.addEventListener('click', toggleLanguage);
-      btnTheme.addEventListener('click', toggleTheme);
-      // Initialize defaults
-      setLanguage(currentLang);
-      setTheme(isDark);
-    })();
-  </script>
+    <script src="../js/page-init.js"></script>
   <div id="modal-root"></div>
   <script src="../js/load-fabs.js"></script>
   <script src="../js/modals.js"></script>

--- a/mainnav/pros.html
+++ b/mainnav/pros.html
@@ -420,75 +420,7 @@
     </form>
   </section>
 
-  <script>
-    (function() {
-      const btnLang = document.getElementById('btn-lang');
-      const btnTheme = document.getElementById('btn-theme');
-      const html = document.documentElement;
-      const body = document.body;
-
-      // Default states
-      let currentLang = 'en';
-      let isDark = (localStorage.getItem('theme') || 'light') === 'dark';
-
-      function setLanguage(lang) {
-        currentLang = lang;
-        html.lang = lang;
-        // Update <title>
-        const titleTag = document.querySelector('title');
-        document.title = titleTag.getAttribute('data-' + lang);
-        // Update all translatable elements
-        document.querySelectorAll('[data-en]').forEach(el => {
-          const text = el.getAttribute('data-' + lang);
-          if (!text) return;
-          if (el.tagName.toLowerCase() === 'input') {
-            el.placeholder = text;
-          } else if (el.tagName.toLowerCase() === 'img') {
-            el.alt = text;
-          } else {
-            el.textContent = text;
-          }
-        });
-        // Update nav links separately for better screen reader experience
-        document.querySelectorAll('nav a').forEach(a => {
-          const text = a.getAttribute('data-' + lang);
-          if (text) a.textContent = text;
-        });
-        // Update toggle language button label and ARIA
-        btnLang.textContent = lang.toUpperCase();
-        btnLang.setAttribute('aria-pressed', lang === 'es');
-      }
-
-      function toggleLanguage() {
-        setLanguage(currentLang === 'en' ? 'es' : 'en');
-      }
-
-      function setTheme(darkMode) {
-        isDark = darkMode;
-        if (darkMode) {
-          body.classList.remove('light');
-          btnTheme.textContent = 'Dark Mode';
-          btnTheme.setAttribute('aria-pressed', 'false');
-        } else {
-          body.classList.add('light');
-          btnTheme.textContent = 'Light Mode';
-          btnTheme.setAttribute('aria-pressed', 'true');
-        }
-        localStorage.setItem('theme', darkMode ? 'dark' : 'light');
-      }
-
-      function toggleTheme() {
-        setTheme(!isDark);
-      }
-
-      btnLang.addEventListener('click', toggleLanguage);
-      btnTheme.addEventListener('click', toggleTheme);
-
-      // Initialize default
-      setLanguage(currentLang);
-      setTheme(isDark);
-    })();
-  </script>
+  <script src="../js/page-init.js"></script>
   <div id="modal-root"></div>
   <script src="../js/load-fabs.js"></script>
   <script src="../js/modals.js"></script>


### PR DESCRIPTION
## Summary
- move language/theme toggle logic into `js/page-init.js`
- reference `page-init.js` from each page under `mainnav`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688b60f532d8832b885184abdcba4adc