### PR TITLE
Fix Join modal styling

### DIFF
--- a/css/contactus.css
+++ b/css/contactus.css
@@ -75,5 +75,5 @@
   button.submit-btn:hover {
     background: var(--clr-accent-dark);
   }
-</style>
+
 .mt-1{margin-top:1rem;}

--- a/css/joinus.css
+++ b/css/joinus.css
@@ -123,5 +123,5 @@
   button.submit-btn:hover {
     background: var(--clr-accent-dark);
   }
-</style>
+
 .hidden{display:none;}

--- a/js/modals.js
+++ b/js/modals.js
@@ -112,6 +112,15 @@ function openChatbotModal() {
 // --- JOIN US MODAL ---
 function openJoinModal() {
   const base = getBasePath();
+
+  // Ensure Join Us styles are loaded once
+  if (!document.querySelector('link[href$="joinus.css"]')) {
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = `${base}/css/joinus.css`;
+    document.head.appendChild(link);
+  }
+
   fetch(`${base}/fabs/joinus.html`)
     .then(r => r.text())
     .then(html => {


### PR DESCRIPTION
## Summary
- load Join Us styles when opening the modal
- remove leftover closing tags in the join and contact CSS

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688be9bf3abc832ba053b3dbada1ab56