### PR TITLE
Fix closing style tags in CSS

### DIFF
--- a/css/center.css
+++ b/css/center.css
@@ -268,7 +268,6 @@
         max-width: 100%;
       }
     }
-  </style>
 .opacity-85{opacity:0.85;}
 .mt-8{margin-top:8px;}
 .mt-15{margin-top:15px;}

--- a/css/contactus.css
+++ b/css/contactus.css
@@ -75,5 +75,4 @@
   button.submit-btn:hover {
     background: var(--clr-accent-dark);
   }
-</style>
-.mt-1{margin-top:1rem;}
+  .mt-1{margin-top:1rem;}

--- a/css/it.css
+++ b/css/it.css
@@ -261,6 +261,5 @@
         max-width: 100%;
       }
     }
-  </style>
-.cta-purple2{background:#512da8;}
+  .cta-purple2{background:#512da8;}
 .section-box{background:rgba(0,0,0,0.15);padding:20px;border-radius:12px;}

--- a/css/joinus.css
+++ b/css/joinus.css
@@ -123,5 +123,4 @@
   button.submit-btn:hover {
     background: var(--clr-accent-dark);
   }
-</style>
-.hidden{display:none;}
+  .hidden{display:none;}

--- a/css/pros.css
+++ b/css/pros.css
@@ -266,6 +266,5 @@
         max-width: 100%;
       }
     }
-  </style>
-.max-w-100{max-width:100%;}
+  .max-w-100{max-width:100%;}
 .section-overlay{background:rgba(255,255,255,0.1);padding:20px;border-radius:14px;}


### PR DESCRIPTION
## Summary
- remove stray `</style>` tags left in CSS files
- keep utility classes like `.hidden` and `.mt-1` intact

## Testing
- `grep -n "</style>" -r css`
- `apt-get update` *(fails: repository access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688be9d76ae4832ba2d40f12fca2c43d