### PR TITLE
Use global sanitizer for forms

### DIFF
--- a/fabs/contactus.html
+++ b/fabs/contactus.html
@@ -69,6 +69,7 @@
       <button type="submit" class="submit-btn">Send</button>
     </div>
   </form>
+  <script src="../js/form-utils.js"></script>
   <script src="../js/contactus.js"></script>
 </body>
 </html>

--- a/fabs/joinus.html
+++ b/fabs/joinus.html
@@ -124,6 +124,7 @@
     </div>
   </form>
 
+<script src="../js/form-utils.js"></script>
 <script src="../js/joinus.js"></script>
 <script>
   document.addEventListener('DOMContentLoaded', () => {

--- a/js/contactus.js
+++ b/js/contactus.js
@@ -1,20 +1,8 @@
-  function sanitizeForm(form) {
-    const fields = form.querySelectorAll('input, textarea');
-    for (const field of fields) {
-      const val = field.value.trim();
-      if (/[<>]/.test(val) || /script/i.test(val)) {
-        return false;
-      }
-      field.value = val;
-    }
-    return true;
-  }
-
   document.addEventListener('DOMContentLoaded', () => {
     const contactForm = document.getElementById('contactForm');
     contactForm.addEventListener('submit', e => {
       e.preventDefault();
-      if (!sanitizeForm(contactForm)) {
+      if (!window.sanitizeForm(contactForm)) {
         alert('Suspicious content detected. Submission rejected.');
         return;
       }

--- a/js/joinus.js
+++ b/js/joinus.js
@@ -80,21 +80,9 @@ function initJoinForm(root) {
     }
   });
 
-  const sanitize = window.sanitizeForm || function(form) {
-    const fields = form.querySelectorAll('input, textarea');
-    for (const field of fields) {
-      const val = field.value.trim();
-      if (/[<>]/.test(val) || /script/i.test(val)) {
-        return false;
-      }
-      field.value = val;
-    }
-    return true;
-  };
-
   joinForm.addEventListener('submit', e => {
     e.preventDefault();
-    if (!sanitize(joinForm)) {
+    if (!window.sanitizeForm(joinForm)) {
       alert('Suspicious content detected. Submission rejected.');
       return;
     }


### PR DESCRIPTION
## Summary
- remove local sanitizeForm functions
- ensure form-utils.js is loaded before form handlers
- invoke the global sanitizeForm when submitting forms

## Testing
- `node -e "const { sanitizeForm } = require('./js/form-utils.js'); function fakeForm(v){return {querySelectorAll:()=>v.map(x=>({value:x}))};} console.log('valid', sanitizeForm(fakeForm(['good','ok']))); console.log('invalid', sanitizeForm(fakeForm(['good','<script>bad</script>'])));"`

------
https://chatgpt.com/codex/tasks/task_e_688beaa7aba0832b8663ced81930a518