### PR TITLE
Fix theme toggle style across pages

### DIFF
--- a/css/center.css
+++ b/css/center.css
@@ -2,15 +2,15 @@
     body {
       font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
       margin: 0; padding: 20px;
-      color: #fff;
-      background: linear-gradient(135deg, #1a237e, #512da8);
+      color: #222;
+      background: #f9f9fb;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
       transition: background 0.3s, color 0.3s;
     }
-    body.light {
-      background: #f9f9fb;
-      color: #222;
+    body.dark {
+      background: linear-gradient(135deg, #1a237e, #512da8);
+      color: #fff;
     }
     /* Navigation */
     nav {
@@ -24,7 +24,7 @@
       flex-wrap: wrap;
     }
     nav a {
-      color: #d3d3ff;
+      color: #444;
       text-decoration: none;
       padding: 8px 16px;
       border-radius: 8px;
@@ -32,17 +32,17 @@
     }
     nav a:hover,
     nav a:focus {
-      background-color: #673ab7;
-      color: white;
-      outline: none;
-    }
-    body.light nav a {
-      color: #444;
-    }
-    body.light nav a:hover,
-    body.light nav a:focus {
       background-color: #b39ddb;
       color: #222;
+      outline: none;
+    }
+    body.dark nav a {
+      color: #d3d3ff;
+    }
+    body.dark nav a:hover,
+    body.dark nav a:focus {
+      background-color: #673ab7;
+      color: white;
     }
 
     /* Toggles container */
@@ -80,7 +80,7 @@
     }
 
     /* Light Mode Overrides */
-    body.light #toggles button {
+    body.dark #toggles button {
       background: linear-gradient(135deg, #f9d423, #ff4e50); /* warm orange-yellow gradient */
       border: 2px solid transparent;
       color: #222222;                /* Dark gray text */
@@ -88,12 +88,12 @@
       background-position: 0% 50%;
       transition: background-position 0.5s ease, color 0.3s, border-color 0.3s;
     }
-    body.light #toggles button:hover {
+    body.dark #toggles button:hover {
       background-position: 100% 50%;  /* shift gradient */
       color: #fff;                   /* white text on hover */
       border-color: #ff4e50;         /* bright orange border */
     }
-    body.light #toggles button.active {
+    body.dark #toggles button.active {
       background: linear-gradient(135deg, #ff512f, #dd2476); /* deeper reddish-pink gradient */
       border-color: #dd2476;
       color: #fff;
@@ -136,12 +136,12 @@
       box-shadow: 0 14px 40px rgba(171, 71, 188, 0.9);
       background: linear-gradient(45deg, #8e24aa, #5e35b1);
     }
-    body.light header a.cta-button {
+    body.dark header a.cta-button {
       background: linear-gradient(45deg, #9c27b0, #ba68c8);
       color: #fff;
       box-shadow: 0 8px 20px rgba(156, 39, 176, 0.5);
     }
-    body.light header a.cta-button:hover {
+    body.dark header a.cta-button:hover {
       box-shadow: 0 14px 40px rgba(156, 39, 176, 0.8);
       background: linear-gradient(45deg, #7b1fa2, #9575cd);
     }
@@ -182,11 +182,11 @@
       margin-top: 10px;
       color: #eee;
     }
-    body.light blockquote {
+    body.dark blockquote {
       color: #555;
       border-left-color: #ba68c8;
     }
-    body.light blockquote strong {
+    body.dark blockquote strong {
       color: #444;
     }
 
@@ -200,7 +200,7 @@
       box-shadow: 0 8px 40px rgba(0,0,0,0.2);
       transition: background 0.3s, color 0.3s;
     }
-    body.light section#form {
+    body.dark section#form {
       background: #fff;
       color: #222;
       box-shadow: 0 8px 40px rgba(0,0,0,0.05);
@@ -224,7 +224,7 @@
       outline: none;
       transition: background 0.3s, color 0.3s;
     }
-    body.light section#form input {
+    body.dark section#form input {
       border: 1px solid #ccc;
       background: #f5f5f7;
       color: #222;
@@ -244,11 +244,11 @@
     section#form button:hover {
       background: #4527a0;
     }
-    body.light section#form button {
+    body.dark section#form button {
       background: #7e57c2;
       color: white;
     }
-    body.light section#form button:hover {
+    body.dark section#form button:hover {
       background: #5e35b1;
     }
 

--- a/css/it.css
+++ b/css/it.css
@@ -2,15 +2,15 @@
     body {
       font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
       margin: 0; padding: 20px;
-      color: #fff;
-      background: linear-gradient(135deg, #1a237e, #512da8);
+      color: #222;
+      background: #f9f9fb;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
       transition: background 0.3s, color 0.3s;
     }
-    body.light {
-      background: #f9f9fb;
-      color: #222;
+    body.dark {
+      background: linear-gradient(135deg, #1a237e, #512da8);
+      color: #fff;
     }
     /* Navigation */
     nav {
@@ -24,7 +24,7 @@
       flex-wrap: wrap;
     }
     nav a {
-      color: #d3d3ff;
+      color: #444;
       text-decoration: none;
       padding: 8px 16px;
       border-radius: 8px;
@@ -32,17 +32,17 @@
     }
     nav a:hover,
     nav a:focus {
-      background-color: #673ab7;
-      color: white;
-      outline: none;
-    }
-    body.light nav a {
-      color: #444;
-    }
-    body.light nav a:hover,
-    body.light nav a:focus {
       background-color: #b39ddb;
       color: #222;
+      outline: none;
+    }
+    body.dark nav a {
+      color: #d3d3ff;
+    }
+    body.dark nav a:hover,
+    body.dark nav a:focus {
+      background-color: #673ab7;
+      color: white;
     }
     /* Toggles container */
     #toggles {
@@ -77,7 +77,7 @@
       color: #a3c9f1;            /* Soft pastel blue text */
     }
     /* Light Mode Overrides */
-    body.light #toggles button {
+    body.dark #toggles button {
       background: linear-gradient(135deg, #f9d423, #ff4e50); /* warm orange-yellow gradient */
       border: 2px solid transparent;
       color: #222222;                /* Dark gray text */
@@ -85,12 +85,12 @@
       background-position: 0% 50%;
       transition: background-position 0.5s ease, color 0.3s, border-color 0.3s;
     }
-    body.light #toggles button:hover {
+    body.dark #toggles button:hover {
       background-position: 100% 50%;  /* shift gradient */
       color: #fff;                   /* white text on hover */
       border-color: #ff4e50;         /* bright orange border */
     }
-    body.light #toggles button.active {
+    body.dark #toggles button.active {
       background: linear-gradient(135deg, #ff512f, #dd2476); /* deeper reddish-pink gradient */
       border-color: #dd2476;
       color: #fff;
@@ -132,12 +132,12 @@
       box-shadow: 0 14px 40px rgba(171, 71, 188, 0.9);
       background: linear-gradient(45deg, #8e24aa, #5e35b1);
     }
-    body.light header a.cta-button {
+    body.dark header a.cta-button {
       background: linear-gradient(45deg, #9c27b0, #ba68c8);
       color: #fff;
       box-shadow: 0 8px 20px rgba(156, 39, 176, 0.5);
     }
-    body.light header a.cta-button:hover {
+    body.dark header a.cta-button:hover {
       box-shadow: 0 14px 40px rgba(156, 39, 176, 0.8);
       background: linear-gradient(45deg, #7b1fa2, #9575cd);
     }
@@ -177,11 +177,11 @@
       margin-top: 10px;
       color: #eee;
     }
-    body.light blockquote {
+    body.dark blockquote {
       color: #555;
       border-left-color: #ba68c8;
     }
-    body.light blockquote strong {
+    body.dark blockquote strong {
       color: #444;
     }
     /* Form */
@@ -194,7 +194,7 @@
       box-shadow: 0 8px 40px rgba(0,0,0,0.2);
       transition: background 0.3s, color 0.3s;
     }
-    body.light section#form {
+    body.dark section#form {
       background: #fff;
       color: #222;
       box-shadow: 0 8px 40px rgba(0,0,0,0.05);
@@ -218,7 +218,7 @@
       outline: none;
       transition: background 0.3s, color 0.3s;
     }
-    body.light section#form input {
+    body.dark section#form input {
       border: 1px solid #ccc;
       background: #f5f5f7;
       color: #222;
@@ -238,11 +238,11 @@
     section#form button:hover {
       background: #4527a0;
     }
-    body.light section#form button {
+    body.dark section#form button {
       background: #7e57c2;
       color: white;
     }
-    body.light section#form button:hover {
+    body.dark section#form button:hover {
       background: #5e35b1;
     }
     /* Responsive */

--- a/css/opera.css
+++ b/css/opera.css
@@ -1,72 +1,69 @@
     /* Reset & base */
     body {
       font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-      color: #fff;
+      color: #222;
       margin: 0; padding: 20px;
-      background: linear-gradient(135deg, #3a30cc, #8e44ad);
+      background: #f0f0f5;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
       transition: background 0.3s, color 0.3s;
     }
     /* Light Theme Styles */
-    body.light {
-      background: #f0f0f5;
-      color: #222;
+    body.dark {
+      background: linear-gradient(135deg, #3a30cc, #8e44ad);
+      color: #fff;
     }
-    body.light header a.cta-button {
+    body.dark header a.cta-button {
       background: linear-gradient(45deg, #ff6600, #e94e1b);
       color: #fff;
       box-shadow: 0 5px 15px rgba(255,102,0,0.5);
     }
-    body.light header a.cta-button:hover {
+    body.dark header a.cta-button:hover {
       box-shadow: 0 10px 25px rgba(255,102,0,0.8);
     }
-    body.light .metrics-card {
+    body.dark .metrics-card {
       background: #fff;
       color: #222;
       box-shadow: 0 8px 24px rgba(0,0,0,0.1);
     }
-    body.light .metrics-card.dark {
+    body.dark .metrics-card.dark {
       background: #f9f9fb;
     }
-    body.light .chart {
+    body.dark .chart {
       background: #d9dbf5;
     }
-    body.light .metrics-values {
+    body.dark .metrics-values {
       color: #555;
     }
-    body.light .stats-section {
+    body.dark .stats-section {
       background: #e8e9f7;
       color: #444;
     }
-    body.light .stat-bar {
+    body.dark .stat-bar {
       background: #c4c7e3;
     }
-    body.light .stat-blue {
+    body.dark .stat-blue {
       background: #4a6eff;
     }
-    body.light .stat-purple {
+    body.dark .stat-purple {
       background: #7a57e8;
     }
-    body.light .stat-light-blue {
+    body.dark .stat-light-blue {
       background: #6c8dff;
     }
-    body.light section#form {
+    body.dark section#form {
       background: #fff;
       color: #222;
       box-shadow: 0 10px 40px rgba(0,0,0,0.08);
     }
-    body.light section#form input {
+    body.dark section#form input {
       background: #f5f5f7;
       color: #222;
       border: 1px solid #ccc;
     }
-    body.light section#form button {
+    body.dark section#form button {
       background: linear-gradient(45deg, #ff6600, #e94e1b);
       color: white;
-    }
-    body.light nav a {
-      color: #222;
     }
     /* Navigation Bar */
     nav {
@@ -79,8 +76,11 @@
       user-select: none;
       flex-wrap: wrap;
     }
-    nav a {
+    body.dark nav a {
       color: #d3d3ff;
+    }
+    nav a {
+      color: #444;
       text-decoration: none;
       padding: 8px 12px;
       border-radius: 6px;
@@ -88,8 +88,8 @@
     }
     nav a:hover,
     nav a:focus {
-      background-color: #9b6cff;
-      color: white;
+      background-color: #b39ddb;
+      color: #222;
       outline: none;
     }
     /* Toggles container */
@@ -125,7 +125,7 @@
       color: #a3c9f1;            /* Soft pastel blue text */
     }
     /* Light Mode Overrides */
-    body.light #toggles button {
+    body.dark #toggles button {
       background: linear-gradient(135deg, #f9d423, #ff4e50); /* warm orange-yellow gradient */
       border: 2px solid transparent;
       color: #222222;                /* Dark gray text */
@@ -134,13 +134,13 @@
       transition: background-position 0.5s ease, color 0.3s, border-color 0.3s;
     }
 
-    body.light #toggles button:hover {
+    body.dark #toggles button:hover {
       background-position: 100% 50%;  /* shift gradient */
       color: #fff;                   /* white text on hover */
       border-color: #ff4e50;         /* bright orange border */
     }
 
-    body.light #toggles button.active {
+    body.dark #toggles button.active {
       background: linear-gradient(135deg, #ff512f, #dd2476); /* deeper reddish-pink gradient */
       border-color: #dd2476;
       color: #fff;

--- a/css/pros.css
+++ b/css/pros.css
@@ -2,15 +2,15 @@
     body {
       font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
       margin: 0; padding: 20px;
-      color: #fff;
-      background: linear-gradient(135deg, #1a237e, #512da8);
+      color: #222;
+      background: #f9f9fb;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
       transition: background 0.3s, color 0.3s;
     }
-    body.light {
-      background: #f9f9fb;
-      color: #222;
+    body.dark {
+      background: linear-gradient(135deg, #1a237e, #512da8);
+      color: #fff;
     }
 
     /* Navigation */
@@ -25,7 +25,7 @@
       flex-wrap: wrap;
     }
     nav a {
-      color: #d3d3ff;
+      color: #444;
       text-decoration: none;
       padding: 8px 16px;
       border-radius: 8px;
@@ -33,17 +33,17 @@
     }
     nav a:hover,
     nav a:focus {
-      background-color: #673ab7;
-      color: white;
-      outline: none;
-    }
-    body.light nav a {
-      color: #444;
-    }
-    body.light nav a:hover,
-    body.light nav a:focus {
       background-color: #b39ddb;
       color: #222;
+      outline: none;
+    }
+    body.dark nav a {
+      color: #d3d3ff;
+    }
+    body.dark nav a:hover,
+    body.dark nav a:focus {
+      background-color: #673ab7;
+      color: white;
     }
 
     /* Toggles container */
@@ -79,7 +79,7 @@
       color: #a3c9f1;            /* Soft pastel blue text */
     }
     /* Light Mode Overrides */
-    body.light #toggles button {
+    body.dark #toggles button {
       background: linear-gradient(135deg, #f9d423, #ff4e50); /* warm orange-yellow gradient */
       border: 2px solid transparent;
       color: #222222;                /* Dark gray text */
@@ -87,12 +87,12 @@
       background-position: 0% 50%;
       transition: background-position 0.5s ease, color 0.3s, border-color 0.3s;
     }
-    body.light #toggles button:hover {
+    body.dark #toggles button:hover {
       background-position: 100% 50%;  /* shift gradient */
       color: #fff;                   /* white text on hover */
       border-color: #ff4e50;         /* bright orange border */
     }
-    body.light #toggles button.active {
+    body.dark #toggles button.active {
       background: linear-gradient(135deg, #ff512f, #dd2476); /* deeper reddish-pink gradient */
       border-color: #dd2476;
       color: #fff;
@@ -134,12 +134,12 @@
       box-shadow: 0 14px 40px rgba(171, 71, 188, 0.9);
       background: linear-gradient(45deg, #8e24aa, #5e35b1);
     }
-    body.light header a.cta-button {
+    body.dark header a.cta-button {
       background: linear-gradient(45deg, #9c27b0, #ba68c8);
       color: #fff;
       box-shadow: 0 8px 20px rgba(156, 39, 176, 0.5);
     }
-    body.light header a.cta-button:hover {
+    body.dark header a.cta-button:hover {
       box-shadow: 0 14px 40px rgba(156, 39, 176, 0.8);
       background: linear-gradient(45deg, #7b1fa2, #9575cd);
     }
@@ -180,11 +180,11 @@
       margin-top: 10px;
       color: #eee;
     }
-    body.light blockquote {
+    body.dark blockquote {
       color: #555;
       border-left-color: #ba68c8;
     }
-    body.light blockquote strong {
+    body.dark blockquote strong {
       color: #444;
     }
 
@@ -198,7 +198,7 @@
       box-shadow: 0 8px 40px rgba(0,0,0,0.2);
       transition: background 0.3s, color 0.3s;
     }
-    body.light section#form {
+    body.dark section#form {
       background: #fff;
       color: #222;
       box-shadow: 0 8px 40px rgba(0,0,0,0.05);
@@ -222,7 +222,7 @@
       outline: none;
       transition: background 0.3s, color 0.3s;
     }
-    body.light section#form input {
+    body.dark section#form input {
       border: 1px solid #ccc;
       background: #f5f5f7;
       color: #222;
@@ -242,11 +242,11 @@
     section#form button:hover {
       background: #4527a0;
     }
-    body.light section#form button {
+    body.dark section#form button {
       background: #7e57c2;
       color: white;
     }
-    body.light section#form button:hover {
+    body.dark section#form button:hover {
       background: #5e35b1;
     }
 

--- a/js/lang-theme.js
+++ b/js/lang-theme.js
@@ -36,15 +36,9 @@
 
   function setTheme(darkMode) {
     isDark = darkMode;
-    if (darkMode) {
-      body.classList.remove('light');
-      btnTheme.textContent = 'Dark Mode';
-      btnTheme.setAttribute('aria-pressed', 'false');
-    } else {
-      body.classList.add('light');
-      btnTheme.textContent = 'Light Mode';
-      btnTheme.setAttribute('aria-pressed', 'true');
-    }
+    body.classList.toggle('dark', darkMode);
+    btnTheme.textContent = darkMode ? 'Light' : 'Dark';
+    btnTheme.setAttribute('aria-pressed', darkMode);
     localStorage.setItem('theme', darkMode ? 'dark' : 'light');
   }
 

--- a/mainnav/center.html
+++ b/mainnav/center.html
@@ -53,7 +53,7 @@
     </div>
     <div class="toggles">
       <button class="toggle-btn" id="btn-lang" aria-label="Toggle language" aria-pressed="false">EN</button>
-      <button class="toggle-btn" id="btn-theme" aria-label="Toggle dark/light theme" aria-pressed="false">Dark Mode</button>
+      <button class="toggle-btn" id="btn-theme" aria-label="Toggle theme" aria-pressed="false">Dark</button>
     </div>
     <button class="hamburger-menu" id="hamburger-menu" aria-label="Toggle Menu">
       <i class="fa-solid fa-bars"></i>

--- a/mainnav/it.html
+++ b/mainnav/it.html
@@ -53,7 +53,7 @@
     </div>
     <div class="toggles">
       <button class="toggle-btn lang-toggle" id="nav-btn-lang" aria-label="Toggle language" aria-pressed="false">EN</button>
-      <button class="toggle-btn theme-toggle" id="nav-btn-theme" aria-label="Toggle dark/light theme" aria-pressed="false">Dark Mode</button>
+      <button class="toggle-btn theme-toggle" id="nav-btn-theme" aria-label="Toggle theme" aria-pressed="false">Dark</button>
     </div>
     <button class="hamburger-menu" id="hamburger-menu" aria-label="Toggle Menu">
       <i class="fa-solid fa-bars"></i>
@@ -62,7 +62,7 @@
   <!-- Toggles for language and theme -->
   <div id="toggles">
     <button class="lang-toggle" id="page-btn-lang" aria-label="Toggle language" aria-pressed="false">EN</button>
-    <button class="theme-toggle" id="page-btn-theme" aria-label="Toggle dark/light theme" aria-pressed="false">Dark Mode</button>
+    <button class="theme-toggle" id="page-btn-theme" aria-label="Toggle theme" aria-pressed="false">Dark</button>
   </div>
   <!-- Header -->
   <header>

--- a/mainnav/opera.html
+++ b/mainnav/opera.html
@@ -53,7 +53,7 @@
     </div>
     <div class="toggles">
       <button class="toggle-btn" id="btn-lang" aria-label="Toggle language" aria-pressed="false">EN</button>
-      <button class="toggle-btn" id="btn-theme" aria-label="Toggle dark/light theme" aria-pressed="false">Dark Mode</button>
+      <button class="toggle-btn" id="btn-theme" aria-label="Toggle theme" aria-pressed="false">Dark</button>
     </div>
     <button class="hamburger-menu" id="hamburger-menu" aria-label="Toggle Menu">
       <i class="fa-solid fa-bars"></i>

--- a/mainnav/pros.html
+++ b/mainnav/pros.html
@@ -49,7 +49,11 @@
       <a href="opera.html" class="nav-link" data-en="Business Operations" data-es="Gestion">Business Operations</a>
       <a href="center.html" class="nav-link" data-en="Contact Center" data-es="Centro de Contacto">Contact Center</a>
       <a href="it.html" class="nav-link" data-en="IT Support" data-es="Soporte IT">IT Support</a>
-      <a href="pros.html" class="nav-link" data-en="Professionals" data-es="Profesionales">Professionals</a>
+    <a href="pros.html" class="nav-link" data-en="Professionals" data-es="Profesionales">Professionals</a>
+    </div>
+    <div class="toggles">
+      <button class="toggle-btn" id="btn-lang" aria-label="Toggle language" aria-pressed="false">EN</button>
+      <button class="toggle-btn" id="btn-theme" aria-label="Toggle theme" aria-pressed="false">Dark</button>
     </div>
     <button class="hamburger-menu" id="hamburger-menu" aria-label="Toggle Menu">
       <i class="fa-solid fa-bars"></i>


### PR DESCRIPTION
## Summary
- update per-page CSS to use `body.dark` for dark theme
- standardize nav link colors for light/dark modes
- align `lang-theme.js` with main theme logic
- ensure theme toggle buttons exist on all main nav pages

## Testing
- `git status --short`
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_688beb96d0ec832b956b06709348ca1b