### PR TITLE
Remove chatbot modal backdrop styles

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -237,16 +237,6 @@
       z-index: 3;
     }
     .modal-x:focus, .close-modal:focus { outline: 2px solid var(--clr-accent); }
-    /* --- CHATBOT (floating modal, draggable) --- */
-    #chatbot-modal-backdrop {
-      position: fixed;
-      z-index: 2900;
-      left: 0; top: 0; right: 0; bottom: 0;
-      background: rgba(44,26,73,0.28);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
     #chatbot-container {
       min-width: 310px;
       max-width: none;


### PR DESCRIPTION
## Summary
- remove unused `#chatbot-modal-backdrop` block from `style.css`

## Testing
- `grep -R chatbot-modal-backdrop -n`

------
https://chatgpt.com/codex/tasks/task_e_688beed702f8832b9593a2324a629dae