### PR TITLE
Fix stray closing tag in contactus CSS

### DIFF
--- a/css/contactus.css
+++ b/css/contactus.css
@@ -74,6 +74,5 @@
   }
   button.submit-btn:hover {
     background: var(--clr-accent-dark);
-  }
-</style>
+}
 .mt-1{margin-top:1rem;}


### PR DESCRIPTION
## Summary
- remove leftover `</style>` from `contactus.css`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688becb499d8832b8bbea8055a3bc445