### PR TITLE
Remove unused chatbot backdrop styles

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -238,15 +238,6 @@
     }
     .modal-x:focus, .close-modal:focus { outline: 2px solid var(--clr-accent); }
     /* --- CHATBOT (floating modal, draggable) --- */
-    #chatbot-modal-backdrop {
-      position: fixed;
-      z-index: 2900;
-      left: 0; top: 0; right: 0; bottom: 0;
-      background: rgba(44,26,73,0.28);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
     #chatbot-container {
       min-width: 310px;
       max-width: none;


### PR DESCRIPTION
## Summary
- delete the `#chatbot-modal-backdrop` block to reduce unused CSS

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_688bf38c8be8832b952505b2576d2a68