### PR TITLE
chore: harden chatbot security headers

### DIFF
--- a/fabs/chatbot.html
+++ b/fabs/chatbot.html
@@ -5,7 +5,11 @@
 <meta name="viewport" content="width=device-width,initial-scale=1.0">
 <meta name="description" content="Interactive AI chatbot assistant for OPS support." />
 <meta name="robots" content="index, follow" />
-<meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' https://cdnjs.cloudflare.com; script-src 'self'; font-src 'self' https://cdnjs.cloudflare.com;">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' https://cdnjs.cloudflare.com; script-src 'self'; font-src 'self' https://cdnjs.cloudflare.com; img-src 'self' data: https://placehold.co;">
+<meta http-equiv="Strict-Transport-Security" content="max-age=63072000; includeSubDomains; preload">
+<meta http-equiv="X-Content-Type-Options" content="nosniff">
+<meta http-equiv="X-Frame-Options" content="SAMEORIGIN">
+<meta name="referrer" content="no-referrer">
 <title>OPS AI Chatbot</title>
 <link rel="stylesheet"
   href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"


### PR DESCRIPTION
## Summary
- replace minimal CSP with full policy and extend security meta headers
- ensure SRI-protected Font Awesome reference is unchanged

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688c2c694ab0832bb5c38c122d549194