### PR TITLE
refactor: centralize theme toggling

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,6 +51,7 @@
   <footer>
     © 2025 OPS Online Support
   </footer>
+  <script src="js/lang-theme.js"></script>
   <script src="js/homepage.js"></script>
   <script src="js/i18n.js"></script>
   <script src="js/load-fabs.js"></script>

--- a/js/lang-theme.js
+++ b/js/lang-theme.js
@@ -1,16 +1,18 @@
 (function(){
   const btnLang = document.getElementById('btn-lang');
-  const btnTheme = document.getElementById('btn-theme');
+  const btnTheme = document.getElementById('btn-theme') || document.getElementById('theme-toggle');
   const html = document.documentElement;
   const body = document.body;
   let currentLang = 'en';
   let isDark = (localStorage.getItem('theme') || 'light') === 'dark';
 
   function setLanguage(lang) {
+    if (!btnLang) return;
     currentLang = lang;
     html.lang = lang;
     const titleTag = document.querySelector('title');
-    document.title = titleTag.getAttribute('data-' + lang);
+    const newTitle = titleTag ? titleTag.getAttribute('data-' + lang) : null;
+    if (newTitle) document.title = newTitle;
     document.querySelectorAll('[data-en]').forEach(el => {
       const text = el.getAttribute('data-' + lang);
       if (!text) return;
@@ -37,8 +39,10 @@
   function setTheme(darkMode) {
     isDark = darkMode;
     body.classList.toggle('dark', darkMode);
-    btnTheme.textContent = darkMode ? 'Light' : 'Dark';
-    btnTheme.setAttribute('aria-pressed', darkMode);
+    if (btnTheme) {
+      btnTheme.textContent = darkMode ? 'Light' : 'Dark';
+      btnTheme.setAttribute('aria-pressed', darkMode);
+    }
     localStorage.setItem('theme', darkMode ? 'dark' : 'light');
   }
 
@@ -46,8 +50,8 @@
     setTheme(!isDark);
   }
 
-  btnLang.addEventListener('click', toggleLanguage);
-  btnTheme.addEventListener('click', toggleTheme);
-  setLanguage(currentLang);
+  if (btnLang) btnLang.addEventListener('click', toggleLanguage);
+  if (btnTheme) btnTheme.addEventListener('click', toggleTheme);
+  if (btnLang) setLanguage(currentLang);
   setTheme(isDark);
 })();

--- a/js/main.js
+++ b/js/main.js
@@ -1,20 +1,11 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const themeToggle = document.getElementById('theme-toggle') || document.getElementById('btn-theme');
-  const langToggle = document.getElementById('lang-toggle') || document.getElementById('btn-lang');
+  const langToggle = document.getElementById('lang-toggle');
 
-  const savedTheme = localStorage.getItem('theme') || 'light';
-  document.body.classList.toggle('dark', savedTheme === 'dark');
-  if (themeToggle) themeToggle.textContent = savedTheme === 'dark' ? 'Light' : 'Dark';
-
-  themeToggle && themeToggle.addEventListener('click', () => {
-    const isDark = document.body.classList.toggle('dark');
-    localStorage.setItem('theme', isDark ? 'dark' : 'light');
-    themeToggle.textContent = isDark ? 'Light' : 'Dark';
-  });
-
-  langToggle && langToggle.addEventListener('click', () => {
-    switchLanguage(lang === 'en' ? 'es' : 'en');
-  });
+  if (langToggle && typeof switchLanguage === 'function') {
+    langToggle.addEventListener('click', () => {
+      switchLanguage(lang === 'en' ? 'es' : 'en');
+    });
+  }
 
   // --- MOBILE NAV ---
   const svcBtn = document.getElementById('svcBtn');


### PR DESCRIPTION
## Summary
- centralize theme handling in lang-theme.js and make it resilient to missing buttons
- drop duplicate theme logic from main.js
- load lang-theme.js on index.html for consistent theme toggling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688c3a6b9270832ba60185f7389a24a4