### PR TITLE
Guard language toggle when i18n missing

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -12,9 +12,24 @@ document.addEventListener('DOMContentLoaded', () => {
     themeToggle.textContent = isDark ? 'Light' : 'Dark';
   });
 
-  langToggle && langToggle.addEventListener('click', () => {
-    switchLanguage(lang === 'en' ? 'es' : 'en');
-  });
+  if (langToggle) {
+    let currentLang = typeof lang !== 'undefined' ? lang : 'en';
+    langToggle.textContent = currentLang === 'en' ? 'ES' : 'EN';
+    langToggle.setAttribute('aria-pressed', currentLang === 'es');
+
+    langToggle.addEventListener('click', () => {
+      const targetLang = currentLang === 'en' ? 'es' : 'en';
+
+      if (typeof switchLanguage === 'function') {
+        switchLanguage(targetLang);
+        currentLang = typeof lang !== 'undefined' ? lang : targetLang;
+      } else {
+        currentLang = targetLang;
+        langToggle.textContent = currentLang === 'en' ? 'ES' : 'EN';
+        langToggle.setAttribute('aria-pressed', currentLang === 'es');
+      }
+    });
+  }
 
   // --- MOBILE NAV ---
   const svcBtn = document.getElementById('svcBtn');

--- a/mainnav/it.html
+++ b/mainnav/it.html
@@ -123,6 +123,7 @@
   <script src="../js/load-fabs.js"></script>
   <script src="../js/form-utils.js"></script>
   <script src="../js/modals.js"></script>
+  <script src="../js/i18n.js"></script>
   <script src="../js/main.js"></script>
   <script src="../js/page-init.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- Safely handle language toggle when i18n library is absent by checking for `switchLanguage` and falling back to local state updates.
- Load i18n script on IT support page so `switchLanguage` and `lang` globals are available before `main.js` runs.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688c3a81a4bc832b9a890756ee16d73a