### PR TITLE
fix: correct CSS references in index

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,8 +15,8 @@
     href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
     integrity="sha512-RXf+QSDCUqpphKAa+WAc3XQ8fE5H1aO/8e2wY+8Q1n8yVwDh1RZTf1TDN8E+u1n7eU5KyY7X2Qo+hqeZZn+UAQ=="
     crossorigin="anonymous" referrerpolicy="no-referrer">
-  <link rel="stylesheet" href="../css/mobile-nav.css">
-  <link rel="stylesheet" href="../css/center.css">
+  <link rel="stylesheet" href="css/mobile-nav.css">
+  <link rel="stylesheet" href="css/center.css">
 </head>
 <body>
   <!-- NAV -->


### PR DESCRIPTION
## Summary
- fix root index CSS paths to point to local `/css` directory

## Testing
- `curl -I http://localhost:8000/css/mobile-nav.css`
- `curl -I http://localhost:8000/css/center.css`

------
https://chatgpt.com/codex/tasks/task_e_688c4d250c70832baf18510f69b32625