### PR TITLE
fix: correct stylesheet paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,8 +15,8 @@
     href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
     integrity="sha512-RXf+QSDCUqpphKAa+WAc3XQ8fE5H1aO/8e2wY+8Q1n8yVwDh1RZTf1TDN8E+u1n7eU5KyY7X2Qo+hqeZZn+UAQ=="
     crossorigin="anonymous" referrerpolicy="no-referrer">
-  <link rel="stylesheet" href="../css/mobile-nav.css">
-  <link rel="stylesheet" href="../css/center.css">
+  <link rel="stylesheet" href="css/mobile-nav.css">
+  <link rel="stylesheet" href="css/center.css">
 </head>
 <body>
   <!-- NAV -->


### PR DESCRIPTION
## Summary
- correct stylesheet links to point to css/mobile-nav.css and css/center.css

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*
- `python3 -m http.server 8000 >/tmp/server.log 2>&1 & echo $! > /tmp/server.pid`
- `curl -I http://localhost:8000/css/mobile-nav.css`
- `curl -I http://localhost:8000/css/center.css`
- `kill $(cat /tmp/server.pid)`

------
https://chatgpt.com/codex/tasks/task_e_688c4dabfadc832ba69cef895738d788