### PR TITLE
Load desktop FAB container

### DIFF
--- a/js/load-fabs.js
+++ b/js/load-fabs.js
@@ -14,6 +14,8 @@
 
   // --- LOAD FABs ---
   const base = window.location.pathname.includes('/mainnav/') ? '..' : '.';
+
+  // Load mobile and desktop FABs sequentially
   fetch(`${base}/fabs/mobile-nav.html`)
     .then(r => {
       if (!r.ok) {
@@ -30,12 +32,27 @@
       } else {
         console.warn('FABs HTML content is empty.');
       }
+      return fetch(`${base}/fabs/fabs-new.html`);
+    })
+    .then(r => {
+      if (!r.ok) {
+        throw new Error(`Failed to fetch desktop FABs: ${r.status}`);
+      }
+      return r.text();
+    })
+    .then(h => {
+      if (h.trim()) {
+        document.body.insertAdjacentHTML('beforeend', h);
+        initBigScreenFabs();
+      } else {
+        console.warn('Desktop FABs HTML content is empty.');
+      }
     })
     .catch(err => console.error('FABs load error:', err));
 
   // --- BIG SCREEN FABs ---
   function initBigScreenFabs() {
-    const fabContainer = document.querySelector('.fab-container');
+    const fabContainer = document.querySelector('#fab-container');
     if (fabContainer) {
       // FABs are displayed or hidden via CSS based on screen size.
       // No special JS logic needed for initialization at this moment.


### PR DESCRIPTION
## Summary
- load desktop FAB markup after mobile nav insertion so `#fab-container` is present on large screens
- target `#fab-container` in big-screen FAB initializer

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688c4db6d9a4832b854e3b185e323fe6