### PR TITLE
fix: remove undefined loadScript call from chatbot modal

### DIFF
--- a/js/modals.js
+++ b/js/modals.js
@@ -129,8 +129,7 @@ function openChatbotModal() {
       document.addEventListener('keydown', function esc(e) { if (e.key === 'Escape') { close(); document.removeEventListener('keydown', esc); } }, { once: true });
       if (typeof makeDraggable === 'function') makeDraggable(modal, modal.querySelector('#chatbot-header'));
 
-      // script must load after DOM elements exist
-      loadScript();
+      // scripts from chatbot.html are appended above and execute automatically
     })
     .catch(err => console.error('Chatbot modal load error', err));
 }


### PR DESCRIPTION
## Summary
- avoid ReferenceError when opening chatbot modal by removing call to undefined `loadScript`

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_688c4e010644832b9b0816d58bdeb26e