### PR TITLE
Add theme toggle element lookup

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
   const langToggle = document.getElementById('lang-toggle');
+  const themeToggle = document.getElementById('theme-toggle');
   const savedTheme = localStorage.getItem('theme') || 'light';
   document.body.classList.toggle('dark', savedTheme === 'dark');
   if (themeToggle) themeToggle.textContent = savedTheme === 'dark' ? 'Light' : 'Dark';


### PR DESCRIPTION
## Summary
- define `themeToggle` in `main.js` by selecting `#theme-toggle`
- ensures theme toggle button text is updated based on saved theme

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688c4eab9a38832b8c84e34aa199dd03