### PR TITLE
dynamically load joinus script for modal

### DIFF
--- a/js/modals.js
+++ b/js/modals.js
@@ -170,7 +170,20 @@ function openJoinModal() {
       m.onclick = e => (e.target === m ? close() : 0);
       modal.querySelector('.modal-x').onclick = close;
       document.addEventListener('keydown', function esc(e) { if (e.key === 'Escape') { close(); document.removeEventListener('keydown', esc); } }, { once: true });
-      if (typeof initJoinForm === 'function') initJoinForm(modal);
+
+      function init() {
+        if (typeof initJoinForm === 'function') initJoinForm(modal);
+      }
+
+      if (typeof initJoinForm === 'function') {
+        init();
+      } else {
+        const script = document.createElement('script');
+        script.src = `${base}/js/joinus.js`;
+        script.onload = init;
+        document.head.appendChild(script);
+      }
+
       if (typeof makeDraggable === 'function') makeDraggable(modal);
     })
     .catch(err => console.error('Join modal load error', err));


### PR DESCRIPTION
## Summary
- dynamically load joinus.js when opening Join Us modal
- initialize Join Us form after modal content is injected

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688c4ed2d0ac832b95568f12014070e1