### PR TITLE
Handle i18n loading failures with fallback language

### DIFF
--- a/js/i18n.js
+++ b/js/i18n.js
@@ -1,10 +1,16 @@
 var lang = 'en';
 var translations = {};
+const fallbackLang = { svc: {} };
 function loadTranslations(l) {
   let base = window.location.pathname.includes('/mainnav/') ? '..' : '.';
   return fetch(base + '/lang/' + l + '.json')
     .then(r => r.json())
-    .then(data => { translations[l] = data; return data; });
+    .then(data => { translations[l] = data; return data; })
+    .catch(err => {
+      console.error('Error loading translations for', l, err);
+      translations[l] = fallbackLang;
+      return translations[l];
+    });
 }
 function applyTranslations() {
   const data = translations[lang];
@@ -27,7 +33,13 @@ function switchLanguage(l) {
     toggle.textContent = l === 'en' ? 'ES' : 'EN';
     toggle.setAttribute('aria-pressed', l === 'es');
   }
-  (translations[l] ? Promise.resolve() : loadTranslations(l)).then(applyTranslations);
+  (translations[l] ? Promise.resolve() : loadTranslations(l))
+    .then(applyTranslations)
+    .catch(err => {
+      console.error('Error switching language to', l, err);
+      translations[l] = fallbackLang;
+      applyTranslations();
+    });
 }
 
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- add fallback language object and error logging for failed translation loads
- ensure language switch logs errors and applies fallback text when fetching fails

## Testing
- `npm test` *(fails: ENOENT could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688c5e2d7520832b8619f6867989cd28