### PR TITLE
Sanitize translation handling to prevent HTML injection

### DIFF
--- a/js/i18n.js
+++ b/js/i18n.js
@@ -1,6 +1,32 @@
 var lang = 'en';
 var translations = {};
 const fallbackLang = { svc: {} };
+
+function sanitizeHTML(html) {
+  const template = document.createElement('template');
+  template.innerHTML = html;
+  const allowedTags = ['i', 'b', 'em', 'strong', 'br', 'a', 'span'];
+  const allowedAttributes = {
+    'i': ['class'],
+    'span': ['class'],
+    'a': ['href', 'title', 'target', 'rel']
+  };
+  const nodes = template.content.querySelectorAll('*');
+  nodes.forEach(node => {
+    const tag = node.nodeName.toLowerCase();
+    if (!allowedTags.includes(tag)) {
+      node.replaceWith(...node.childNodes);
+    } else {
+      [...node.attributes].forEach(attr => {
+        const allowed = allowedAttributes[tag] || [];
+        if (!allowed.includes(attr.name.toLowerCase())) {
+          node.removeAttribute(attr.name);
+        }
+      });
+    }
+  });
+  return template.innerHTML;
+}
 function loadTranslations(l) {
   let base = window.location.pathname.includes('/mainnav/') ? '..' : '.';
   return fetch(base + '/lang/' + l + '.json')
@@ -21,7 +47,15 @@ function applyTranslations() {
     const key = el.getAttribute('data-i18n').split('.');
     let text = data;
     key.forEach(k => { if (text) text = text[k]; });
-    if (text) el.innerHTML = text;
+    if (typeof text === 'string') {
+      if (/<[a-z][\s\S]*>/i.test(text)) {
+        el.innerHTML = sanitizeHTML(text);
+      } else {
+        el.textContent = text;
+      }
+    } else if (text) {
+      el.textContent = text;
+    }
   });
   if (typeof renderCards === 'function') renderCards();
 }


### PR DESCRIPTION
## Summary
- sanitize translated strings via a whitelist-based sanitizer
- use `textContent` for plain translations to avoid unintended HTML
- verified language files only contain trusted `<i>` tags for icons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688c6665722c832b833c66fb26cc8556