### PR TITLE
Use solid user-plus icon for Join Us button

### DIFF
--- a/fabs/fabs-new.html
+++ b/fabs/fabs-new.html
@@ -2,5 +2,5 @@
 <div id="fab-container">
   <button onclick="openChatbotModal()" title="Chatbot"><i class="fa fa-comment"></i></button>
   <button onclick="openContactModal()" title="Contact Us"><i class="fa fa-envelope"></i></button>
-  <button onclick="openJoinModal()" title="Join Us"><i class="fa fa-user-plus"></i></button>
+  <button onclick="openJoinModal()" title="Join Us"><i class="fa-solid fa-user-plus"></i></button>
 </div>

--- a/fabs/mobile-nav.html
+++ b/fabs/mobile-nav.html
@@ -1,7 +1,7 @@
 <div id="mobileNav" class="mobile-nav" aria-label="Mobile navigation">
   <div class="nav-items">
     <button onclick="openContactModal()" class="nav-btn" title="Contact Us" aria-label="Contact Us"><i class="fa fa-envelope"></i></button>
-    <button onclick="openJoinModal()" class="nav-btn" title="Join Us" aria-label="Join Us"><i class="fa fa-user-plus"></i></button>
+    <button onclick="openJoinModal()" class="nav-btn" title="Join Us" aria-label="Join Us"><i class="fa-solid fa-user-plus"></i></button>
     <button onclick="openChatbotModal()" class="nav-btn" title="Chatbot" aria-label="Chatbot"><i class="fa fa-comment"></i></button>
     <button id="lang-toggle" class="nav-btn" aria-label="Toggle language">ES</button>
     <button id="theme-toggle" class="nav-btn" aria-label="Toggle theme">Dark</button>

--- a/js/load-fabs.js
+++ b/js/load-fabs.js
@@ -79,7 +79,7 @@
     const mobileNavHTML = `<div id="mobileNav" class="mobile-nav" aria-label="Mobile navigation">
   <div class="nav-items">
     <button onclick="openContactModal()" class="nav-btn" title="Contact Us" aria-label="Contact Us"><i class="fa fa-envelope"></i></button>
-    <button onclick="openJoinModal()" class="nav-btn" title="Join Us" aria-label="Join Us"><i class="fa fa-user-plus"></i></button>
+    <button onclick="openJoinModal()" class="nav-btn" title="Join Us" aria-label="Join Us"><i class="fa-solid fa-user-plus"></i></button>
     <button onclick="openChatbotModal()" class="nav-btn" title="Chatbot" aria-label="Chatbot"><i class="fa fa-comment"></i></button>
     <button id="lang-toggle" class="nav-btn" aria-label="Toggle language">ES</button>
     <button id="theme-toggle" class="nav-btn" aria-label="Toggle theme">Dark</button>
@@ -100,7 +100,7 @@
   </button>
 </div>`;
 
-    const fabsHTML = `<!-- Floating Action Buttons snippet -->\n<div id="fab-container">\n  <button onclick="openChatbotModal()" title="Chatbot"><i class="fa fa-comment"></i></button>\n  <button onclick="openContactModal()" title="Contact Us"><i class="fa fa-envelope"></i></button>\n  <button onclick="openJoinModal()" title="Join Us"><i class="fa fa-user-plus"></i></button>\n</div>`;
+    const fabsHTML = `<!-- Floating Action Buttons snippet -->\n<div id="fab-container">\n  <button onclick="openChatbotModal()" title="Chatbot"><i class="fa fa-comment"></i></button>\n  <button onclick="openContactModal()" title="Contact Us"><i class="fa fa-envelope"></i></button>\n  <button onclick="openJoinModal()" title="Join Us"><i class="fa-solid fa-user-plus"></i></button>\n</div>`;
 
     appendToBody(mobileNavHTML);
     appendToBody(fabsHTML);


### PR DESCRIPTION
## Summary
- use `fa-solid fa-user-plus` for Join Us icons to align with Font Awesome 6

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688c670bb4e0832b8517758caba1ff86