### PR TITLE
feat: improve language toggle accessibility

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -23,6 +23,18 @@
       background: linear-gradient(135deg, #191632 0%, #1a1930 100%);
       color: #fafbfe;
     }
+
+    .visually-hidden {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
     /* NAV */
     .ops-nav {
       width: 100%;

--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
     <div class="toggles">
       <button class="toggle-btn" id="lang-toggle" aria-label="Toggle language" aria-pressed="false">EN</button>
       <button class="toggle-btn" id="theme-toggle" aria-label="Toggle theme" aria-pressed="false">Dark</button>
+      <span id="lang-status" class="visually-hidden" aria-live="polite"></span>
     </div>
     <button class="hamburger-menu" id="hamburger-menu" aria-label="Toggle Menu">
       <i class="fa-solid fa-bars"></i>

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -32,7 +32,10 @@ function switchLanguage(l) {
   if (toggle) {
     toggle.textContent = l === 'en' ? 'ES' : 'EN';
     toggle.setAttribute('aria-pressed', l === 'es');
+    toggle.setAttribute('aria-label', l === 'en' ? 'Switch to Spanish' : 'Switch to English');
   }
+  const status = document.getElementById('lang-status');
+  if (status) status.textContent = l === 'en' ? 'English selected' : 'Spanish selected';
   (translations[l] ? Promise.resolve() : loadTranslations(l))
     .then(applyTranslations)
     .catch(err => {

--- a/js/main.js
+++ b/js/main.js
@@ -12,18 +12,21 @@ document.addEventListener('DOMContentLoaded', () => {
 
   if (langToggle) {
     let currentLang = typeof lang !== 'undefined' ? lang : 'en';
-    langToggle.textContent = currentLang === 'en' ? 'ES' : 'EN';
-    langToggle.setAttribute('aria-pressed', currentLang === 'es');
+    const updateToggle = (l) => {
+      langToggle.textContent = l === 'en' ? 'ES' : 'EN';
+      langToggle.setAttribute('aria-pressed', l === 'es');
+      langToggle.setAttribute('aria-label', l === 'en' ? 'Switch to Spanish' : 'Switch to English');
+      const status = document.getElementById('lang-status');
+      if (status) status.textContent = l === 'en' ? 'English selected' : 'Spanish selected';
+    };
+    updateToggle(currentLang);
     langToggle.addEventListener('click', () => {
       const targetLang = currentLang === 'en' ? 'es' : 'en';
       if (typeof switchLanguage === 'function') {
         switchLanguage(targetLang);
-        currentLang = typeof lang !== 'undefined' ? lang : targetLang;
-      } else {
-        currentLang = targetLang;
-        langToggle.textContent = currentLang === 'en' ? 'ES' : 'EN';
-        langToggle.setAttribute('aria-pressed', currentLang === 'es');
       }
+      currentLang = targetLang;
+      updateToggle(currentLang);
     });
   }
 

--- a/mainnav/center.html
+++ b/mainnav/center.html
@@ -52,6 +52,7 @@
     <div class="toggles">
       <button class="toggle-btn" id="lang-toggle" aria-label="Toggle language" aria-pressed="false">EN</button>
       <button class="toggle-btn" id="theme-toggle" aria-label="Toggle theme" aria-pressed="false">Dark</button>
+      <span id="lang-status" class="visually-hidden" aria-live="polite"></span>
     </div>
     <button class="hamburger-menu" id="hamburger-menu" aria-label="Toggle Menu">
       <i class="fa-solid fa-bars"></i>

--- a/mainnav/it.html
+++ b/mainnav/it.html
@@ -52,6 +52,7 @@
     <div class="toggles">
       <button class="toggle-btn" id="lang-toggle" aria-label="Toggle language" aria-pressed="false">EN</button>
       <button class="toggle-btn" id="theme-toggle" aria-label="Toggle theme" aria-pressed="false">Dark</button>
+      <span id="lang-status" class="visually-hidden" aria-live="polite"></span>
     </div>
     <button class="hamburger-menu" id="hamburger-menu" aria-label="Toggle Menu">
       <i class="fa-solid fa-bars"></i>

--- a/mainnav/opera.html
+++ b/mainnav/opera.html
@@ -52,6 +52,7 @@
     <div class="toggles">
       <button class="toggle-btn" id="lang-toggle" aria-label="Toggle language" aria-pressed="false">EN</button>
       <button class="toggle-btn" id="theme-toggle" aria-label="Toggle theme" aria-pressed="false">Dark</button>
+      <span id="lang-status" class="visually-hidden" aria-live="polite"></span>
     </div>
     <button class="hamburger-menu" id="hamburger-menu" aria-label="Toggle Menu">
       <i class="fa-solid fa-bars"></i>

--- a/mainnav/pros.html
+++ b/mainnav/pros.html
@@ -52,6 +52,7 @@
     <div class="toggles">
       <button class="toggle-btn" id="lang-toggle" aria-label="Toggle language" aria-pressed="false">EN</button>
       <button class="toggle-btn" id="theme-toggle" aria-label="Toggle theme" aria-pressed="false">Dark</button>
+      <span id="lang-status" class="visually-hidden" aria-live="polite"></span>
     </div>
     <button class="hamburger-menu" id="hamburger-menu" aria-label="Toggle Menu">
       <i class="fa-solid fa-bars"></i>


### PR DESCRIPTION
## Summary
- add visually hidden aria-live region next to language toggle on index and main navigation pages
- update toggle script to announce target language and manage aria-pressed
- centralize live announcements and aria-label updates in i18n handler

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688c668bdad8832ba685b55a18f1bc89