### PR TITLE
Improve Join Us modal error handling

### DIFF
--- a/js/modals.js
+++ b/js/modals.js
@@ -153,6 +153,13 @@ function openChatbotModal() {
 function openJoinModal() {
   const base = getBasePath();
 
+  const root = document.getElementById('modal-root');
+  if (!root) {
+    console.error('Join modal root element (#modal-root) not found');
+    alert('Unable to open Join modal.');
+    return;
+  }
+
   // Ensure Join Us styles are loaded once
   if (!document.querySelector('link[href$="joinus.css"]')) {
     const link = document.createElement('link');
@@ -162,7 +169,12 @@ function openJoinModal() {
   }
 
   fetch(`${base}/fabs/joinus.html`)
-    .then(r => r.text())
+    .then(r => {
+      if (!r.ok) {
+        throw new Error(`Failed to load Join Us modal: ${r.status} ${r.statusText}`);
+      }
+      return r.text();
+    })
     .then(html => {
       const doc = new DOMParser().parseFromString(html, 'text/html');
       const body = doc.body.innerHTML;
@@ -173,7 +185,6 @@ function openJoinModal() {
           <button class="modal-x" aria-label="CERRAR">X</button>
           ${body}
         </div>`;
-      const root = document.getElementById('modal-root');
       root.innerHTML = '';
       root.appendChild(m);
       const modal = m.querySelector('.ops-modal');
@@ -200,5 +211,8 @@ function openJoinModal() {
 
       if (typeof makeDraggable === 'function') makeDraggable(modal);
     })
-    .catch(err => console.error('Join modal load error', err));
+    .catch(err => {
+      console.error('Join modal load error', err);
+      alert('Unable to load Join Us modal.');
+    });
 }


### PR DESCRIPTION
## Summary
- ensure `#modal-root` exists before rendering Join Us modal
- add descriptive error handling for Join Us modal fetch failures

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688c67732148832b9b76d63647b2e004