### PR TITLE
Use Font Awesome 6 envelope icon

### DIFF
--- a/fabs/fabs-new.html
+++ b/fabs/fabs-new.html
@@ -1,6 +1,6 @@
 <!-- Floating Action Buttons snippet -->
 <div id="fab-container">
   <button onclick="openChatbotModal()" title="Chatbot"><i class="fa fa-comment"></i></button>
-  <button onclick="openContactModal()" title="Contact Us"><i class="fa fa-envelope"></i></button>
+  <button onclick="openContactModal()" title="Contact Us"><i class="fa-solid fa-envelope"></i></button>
   <button onclick="openJoinModal()" title="Join Us"><i class="fa fa-user-plus"></i></button>
 </div>

--- a/fabs/mobile-nav.html
+++ b/fabs/mobile-nav.html
@@ -1,6 +1,6 @@
 <div id="mobileNav" class="mobile-nav" aria-label="Mobile navigation">
   <div class="nav-items">
-    <button onclick="openContactModal()" class="nav-btn" title="Contact Us" aria-label="Contact Us"><i class="fa fa-envelope"></i></button>
+    <button onclick="openContactModal()" class="nav-btn" title="Contact Us" aria-label="Contact Us"><i class="fa-solid fa-envelope"></i></button>
     <button onclick="openJoinModal()" class="nav-btn" title="Join Us" aria-label="Join Us"><i class="fa fa-user-plus"></i></button>
     <button onclick="openChatbotModal()" class="nav-btn" title="Chatbot" aria-label="Chatbot"><i class="fa fa-comment"></i></button>
     <button id="lang-toggle" class="nav-btn" aria-label="Toggle language">ES</button>

--- a/js/load-fabs.js
+++ b/js/load-fabs.js
@@ -78,7 +78,7 @@
   if (window.location.protocol === 'file:') {
     const mobileNavHTML = `<div id="mobileNav" class="mobile-nav" aria-label="Mobile navigation">
   <div class="nav-items">
-    <button onclick="openContactModal()" class="nav-btn" title="Contact Us" aria-label="Contact Us"><i class="fa fa-envelope"></i></button>
+    <button onclick="openContactModal()" class="nav-btn" title="Contact Us" aria-label="Contact Us"><i class="fa-solid fa-envelope"></i></button>
     <button onclick="openJoinModal()" class="nav-btn" title="Join Us" aria-label="Join Us"><i class="fa fa-user-plus"></i></button>
     <button onclick="openChatbotModal()" class="nav-btn" title="Chatbot" aria-label="Chatbot"><i class="fa fa-comment"></i></button>
     <button id="lang-toggle" class="nav-btn" aria-label="Toggle language">ES</button>
@@ -100,7 +100,7 @@
   </button>
 </div>`;
 
-    const fabsHTML = `<!-- Floating Action Buttons snippet -->\n<div id="fab-container">\n  <button onclick="openChatbotModal()" title="Chatbot"><i class="fa fa-comment"></i></button>\n  <button onclick="openContactModal()" title="Contact Us"><i class="fa fa-envelope"></i></button>\n  <button onclick="openJoinModal()" title="Join Us"><i class="fa fa-user-plus"></i></button>\n</div>`;
+    const fabsHTML = `<!-- Floating Action Buttons snippet -->\n<div id="fab-container">\n  <button onclick="openChatbotModal()" title="Chatbot"><i class="fa fa-comment"></i></button>\n  <button onclick="openContactModal()" title="Contact Us"><i class="fa-solid fa-envelope"></i></button>\n  <button onclick="openJoinModal()" title="Join Us"><i class="fa fa-user-plus"></i></button>\n</div>`;
 
     appendToBody(mobileNavHTML);
     appendToBody(fabsHTML);


### PR DESCRIPTION
## Summary
- update envelope icon in mobile nav and floating action buttons to use Font Awesome 6's `fa-solid fa-envelope`
- ensure dynamic FAB injection uses the updated icon class

## Testing
- `node -e "['fabs/fabs-new.html','fabs/mobile-nav.html'].forEach(f=>{const c=require('fs').readFileSync(f,'utf8'); console.log(f, c.includes('fa-solid fa-envelope'));})"`
- `node - <<'NODE'
global.window = { location: { protocol: 'file:', pathname: '/' }, initMobileNav: function(){ }};
const inserted = [];
global.document = {
  head: { appendChild(){ } },
  body: { insertAdjacentHTML: (pos, html) => inserted.push(html) },
  createElement: () => ({ rel:'', href:'', integrity:'', crossOrigin:'', }),
  querySelector: () => null
};
global.fetch = () => Promise.resolve({ ok: true, text: () => Promise.resolve('') });
require('./js/load-fabs.js');
const hasEnvelope = inserted.some(html => html.includes('fa-solid fa-envelope'));
console.log('dynamic contains fa-solid fa-envelope:', hasEnvelope);
NODE`
- `npx -y -p jsdom node - <<'NODE'
const {JSDOM} = require('jsdom');
const fs = require('fs');
const html = fs.readFileSync('fabs/fabs-new.html','utf8');
const dom = new JSDOM(html);
console.log(dom.window.document.querySelector('i.fa-solid.fa-envelope') ? 'found in fabs-new' : 'not found');
NODE` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688c67b67c00832ba968418a92d62d78