### PR TITLE
fix modal base path

### DIFF
--- a/js/modals.js
+++ b/js/modals.js
@@ -8,8 +8,8 @@ const svcMenu = document.getElementById('svcMenu');
 let dark=false;
 
 function getBasePath() {
-  const depth = window.location.pathname.split('/').length - 2;
-  return depth > 0 ? '../'.repeat(depth) : '.';
+  const url = new URL('.', document.baseURI || window.location.href);
+  return url.pathname.replace(/\/$/, '');
 }
 
 if (toggleNav) {
@@ -98,7 +98,10 @@ function openContactModal() {
       }
       if (typeof makeDraggable === 'function') makeDraggable(modal);
     })
-    .catch(err => console.error('Contact modal load error', err));
+    .catch(err => {
+      console.error('Contact modal load error', err);
+      alert('Unable to load contact form. Please try again later.');
+    });
 }
 
 // --- CHATBOT MODAL ---


### PR DESCRIPTION
## Summary
- derive base path using `new URL`/`document.baseURI` so modals work from subdirectories
- alert user if contact modal HTML fails to load

## Testing
- `node --check js/modals.js`
- `node - <<'NODE'
const fs=require('fs');
const vm=require('vm');
const code=fs.readFileSync('./js/modals.js','utf8');
function test(path){
  const context={
    window:{location:{href:`http://example.com${path}/index.html`}},
    document:{baseURI:`http://example.com${path}/index.html`,getElementById:()=>null,documentElement:{}},
    alert:(msg)=>console.log('alert:',msg),
    console:console,
    fetch:(url)=>{console.log('fetch called:',url);return Promise.reject(new Error('fail'));},
    URL: URL
  };
  vm.createContext(context);
  vm.runInContext(code,context);
  context.openContactModal();
}
console.log('Testing root');
test('');
console.log('Testing nested');
test('/nested/depth');
NODE`

------
https://chatgpt.com/codex/tasks/task_e_688c67bb4720832b9e8eaa15e2680708