### PR TITLE
Handle contact modal load errors with accessible alert

### DIFF
--- a/js/modals.js
+++ b/js/modals.js
@@ -98,7 +98,21 @@ function openContactModal() {
       }
       if (typeof makeDraggable === 'function') makeDraggable(modal);
     })
-    .catch(err => console.error('Contact modal load error', err));
+    .catch(err => {
+      console.error('Contact modal load error', err);
+      const root = document.getElementById('modal-root');
+      const message = 'Unable to load contact form. Please try again or email us at support@example.com.';
+      if (root) {
+        root.innerHTML = '';
+        const msg = document.createElement('div');
+        msg.setAttribute('role', 'alert');
+        msg.className = 'modal-error';
+        msg.textContent = message;
+        root.appendChild(msg);
+      } else {
+        alert(message);
+      }
+    });
 }
 
 // --- CHATBOT MODAL ---


### PR DESCRIPTION
## Summary
- display an accessible alert when the contact modal fails to load
- guide users to retry or email support

## Testing
- `npm test` *(fails: could not read package.json)*
- Manual simulation of failed fetch to verify alert rendering


------
https://chatgpt.com/codex/tasks/task_e_688c699b7ab4832b80b884f90e70de93