### PR TITLE
Load and cleanup contact modal styles

### DIFF
--- a/js/modals.js
+++ b/js/modals.js
@@ -65,7 +65,22 @@ function openContactModal() {
       root.appendChild(m);
       const modal = m.querySelector('.ops-modal');
       modal.focus();
-      function close() { root.innerHTML = ''; }
+
+      const addedLinks = [];
+      ['style.css', 'contactus.css'].forEach(file => {
+        if (!document.querySelector(`link[href$="${file}"]`)) {
+          const link = document.createElement('link');
+          link.rel = 'stylesheet';
+          link.href = `${base}/css/${file}`;
+          document.head.appendChild(link);
+          addedLinks.push(link);
+        }
+      });
+
+      function close() {
+        root.innerHTML = '';
+        addedLinks.forEach(l => l.remove());
+      }
       const handleClose = () => { close(); };
       window.addEventListener('modal-close', handleClose, { once: true });
       m.onclick = e => (e.target === m ? close() : 0);


### PR DESCRIPTION
## Summary
- load `contactus.css` and `style.css` when opening the Contact Us modal if missing
- remove dynamically injected style links once the modal closes to prevent duplicates

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688c699faf5c832ba1b84a2a7bc3ca10