### PR TITLE
refactor: simplify modal handling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -170,15 +170,6 @@
     }
     body.dark .card .icon > i { filter: drop-shadow(0 0 2px #00c4ff55); }
     /* --- MODAL BASE --- */
-    .modal-backdrop {
-      position: fixed;
-      z-index: 1999;
-      left: 0; top: 0; right: 0; bottom: 0;
-      background: rgba(44,26,73,0.31);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
     .ops-modal, .modal-content, #chatbot-container {
       min-width: 310px;
       max-width: none;
@@ -189,7 +180,7 @@
       border-radius: 2rem;
       box-shadow: 0 6px 60px #5e24bb25, 0 0 0 2px #fff1;
       padding: 2.1rem 2.2rem 1.3rem 2.2rem;
-      position: absolute;
+      position: fixed;
       left: 50%;
       top: 50%;
       transform: translate(-50%, -50%);
@@ -383,7 +374,11 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  position: relative;
+  position: fixed;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 2222;
   animation: popIn .18s cubic-bezier(.47,1.64,.41,.8);
 }
 

--- a/js/homepage.js
+++ b/js/homepage.js
@@ -22,10 +22,13 @@ function renderCards() {
 function openModal(key) {
   const data = svc[key].modal;
   const labels = translations[lang].labels;
-  const m = document.createElement('div');
-  m.className = 'modal-backdrop';
-  m.innerHTML = `
-    <div class="modal" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="modal-title-${key}">
+  const modal = document.createElement('div');
+  modal.className = 'modal';
+  modal.setAttribute('tabindex', '-1');
+  modal.setAttribute('role', 'dialog');
+  modal.setAttribute('aria-modal', 'true');
+  modal.setAttribute('aria-labelledby', `modal-title-${key}`);
+  modal.innerHTML = `
       <button class="modal-close" aria-label="Close modal">&times;</button>
       <div class="modal-header">
         <img src="${data.img}" alt="${data.imgAlt}" />
@@ -44,18 +47,15 @@ function openModal(key) {
         <button class="footer-btn" id="join-us">${labels.join}</button>
         <button class="footer-btn cta" id="modal-contact-btn">${labels.contact}</button>
         <button class="footer-btn cancel" id="cancel-btn">${labels.cancel}</button>
-      </div>
-    </div>`;
-  const root = document.getElementById('modal-root');
+      </div>`;
+  const root = document.getElementById('modal-root') || document.body;
   root.innerHTML = '';
-  root.appendChild(m);
-  const modal = m.querySelector('.modal');
+  root.appendChild(modal);
   modal.focus();
-  function close() { root.innerHTML = ''; }
-  m.onclick = e => { if (e.target === m) close(); };
-  modal.querySelector('.modal-close').onclick = close;
+  let detach;
+  function close() { root.innerHTML = ''; if (detach) detach(); }
+  detach = attachModalClose(modal, close);
   modal.querySelector('#cancel-btn').onclick = close;
-  document.addEventListener('keydown', function esc(e){ if(e.key==='Escape'){ close(); document.removeEventListener('keydown', esc); } }, { once:true });
   modal.querySelector('#modal-contact-btn').onclick = ()=>{ openContactModal(); close(); };
   modal.querySelector('#ask-chattia').onclick = ()=>{ openChatbotModal(); close(); };
   modal.querySelector('#join-us').onclick = ()=>{ openJoinModal(); close(); };

--- a/js/modals.js
+++ b/js/modals.js
@@ -12,6 +12,28 @@ function getBasePath() {
   return url.pathname.replace(/\/$/, '');
 }
 
+function attachModalClose(modal, close) {
+  function handleClick(e) {
+    if (!modal.contains(e.target)) {
+      close();
+    }
+  }
+  function handleKey(e) {
+    if (e.key === 'Escape') {
+      close();
+    }
+  }
+  const btn = modal.querySelector('.modal-x, #chatbot-x, .modal-close');
+  if (btn) btn.addEventListener('click', close);
+  document.addEventListener('click', handleClick);
+  document.addEventListener('keydown', handleKey);
+  return () => {
+    document.removeEventListener('click', handleClick);
+    document.removeEventListener('keydown', handleKey);
+    if (btn) btn.removeEventListener('click', close);
+  };
+}
+
 if (toggleNav) {
   toggleNav.onclick = ()=>{
     mobileNav.classList.toggle('open');
@@ -53,17 +75,17 @@ function openContactModal() {
       const scriptNodes = [...doc.querySelectorAll('script')];
       scriptNodes.forEach(s => s.remove());
       const body = doc.body.innerHTML;
-      const m = document.createElement('div');
-      m.className = 'modal-backdrop';
-      m.innerHTML = `
-        <div class="ops-modal" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="contact-title" id="contact-modal">
-          <button class="modal-x" aria-label="CERRAR">X</button>
-          ${body}
-        </div>`;
-      const root = document.getElementById('modal-root');
+      const modal = document.createElement('div');
+      modal.className = 'ops-modal';
+      modal.setAttribute('tabindex', '-1');
+      modal.setAttribute('role', 'dialog');
+      modal.setAttribute('aria-modal', 'true');
+      modal.setAttribute('aria-labelledby', 'contact-title');
+      modal.id = 'contact-modal';
+      modal.innerHTML = `<button class="modal-x" aria-label="CERRAR">X</button>${body}`;
+      const root = document.getElementById('modal-root') || document.body;
       root.innerHTML = '';
-      root.appendChild(m);
-      const modal = m.querySelector('.ops-modal');
+      root.appendChild(modal);
       modal.focus();
 
       const addedLinks = [];
@@ -77,15 +99,14 @@ function openContactModal() {
         }
       });
 
+      let detach;
       function close() {
         root.innerHTML = '';
         addedLinks.forEach(l => l.remove());
+        if (detach) detach();
       }
-      const handleClose = () => { close(); };
-      window.addEventListener('modal-close', handleClose, { once: true });
-      m.onclick = e => (e.target === m ? close() : 0);
-      modal.querySelector('.modal-x').onclick = close;
-      document.addEventListener('keydown', function esc(e) { if (e.key === 'Escape') { close(); document.removeEventListener('keydown', esc); } }, { once: true });
+      window.addEventListener('modal-close', close, { once: true });
+      detach = attachModalClose(modal, close);
 
       // append and execute scripts from fetched HTML
       scriptNodes.forEach(s => {
@@ -140,11 +161,15 @@ function openChatbotModal() {
       const body = doc.body.innerHTML;
       const scriptNodes = [...doc.querySelectorAll('script')];
 
-      const m = document.createElement('div');
-      m.id = 'chatbot-modal-backdrop';
-      m.innerHTML = `<div id="chatbot-container" class="ops-modal" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="title">${body}</div>`;
-      document.body.appendChild(m);
-      const modal = m.querySelector('.ops-modal');
+      const modal = document.createElement('div');
+      modal.id = 'chatbot-container';
+      modal.className = 'ops-modal';
+      modal.setAttribute('tabindex', '-1');
+      modal.setAttribute('role', 'dialog');
+      modal.setAttribute('aria-modal', 'true');
+      modal.setAttribute('aria-labelledby', 'title');
+      modal.innerHTML = body;
+      document.body.appendChild(modal);
       modal.focus();
 
       // track scripts added so we can remove them on close
@@ -164,13 +189,13 @@ function openChatbotModal() {
         }
       });
 
+      let detach;
       function close() {
         addedScripts.forEach(el => el.remove());
-        document.body.removeChild(m);
+        document.body.removeChild(modal);
+        if (detach) detach();
       }
-      m.onclick = e => (e.target === m ? close() : 0);
-      modal.querySelector('#chatbot-x').onclick = close;
-      document.addEventListener('keydown', function esc(e) { if (e.key === 'Escape') { close(); document.removeEventListener('keydown', esc); } }, { once: true });
+      detach = attachModalClose(modal, close);
       if (typeof makeDraggable === 'function') makeDraggable(modal, modal.querySelector('#chatbot-header'));
 
       // scripts from chatbot.html are appended above and execute automatically
@@ -207,23 +232,24 @@ function openJoinModal() {
     .then(html => {
       const doc = new DOMParser().parseFromString(html, 'text/html');
       const body = doc.body.innerHTML;
-      const m = document.createElement('div');
-      m.className = 'modal-backdrop';
-      m.innerHTML = `
-        <div class="ops-modal" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="joinus-title" id="join-modal">
-          <button class="modal-x" aria-label="CERRAR">X</button>
-          ${body}
-        </div>`;
+      const modal = document.createElement('div');
+      modal.className = 'ops-modal';
+      modal.setAttribute('tabindex', '-1');
+      modal.setAttribute('role', 'dialog');
+      modal.setAttribute('aria-modal', 'true');
+      modal.setAttribute('aria-labelledby', 'joinus-title');
+      modal.id = 'join-modal';
+      modal.innerHTML = `<button class="modal-x" aria-label="CERRAR">X</button>${body}`;
       root.innerHTML = '';
-      root.appendChild(m);
-      const modal = m.querySelector('.ops-modal');
+      root.appendChild(modal);
       modal.focus();
-      function close() { root.innerHTML = ''; }
-      const handleClose = () => { close(); };
-      window.addEventListener('modal-close', handleClose, { once: true });
-      m.onclick = e => (e.target === m ? close() : 0);
-      modal.querySelector('.modal-x').onclick = close;
-      document.addEventListener('keydown', function esc(e) { if (e.key === 'Escape') { close(); document.removeEventListener('keydown', esc); } }, { once: true });
+      let detach;
+      function close() {
+        root.innerHTML = '';
+        if (detach) detach();
+      }
+      window.addEventListener('modal-close', close, { once: true });
+      detach = attachModalClose(modal, close);
 
       function init() {
         if (typeof initJoinForm === 'function') initJoinForm(modal);


### PR DESCRIPTION
## Summary
- simplify modal handling by appending `.ops-modal` directly to the DOM
- add shared `attachModalClose` to handle outside clicks and Esc key
- remove deprecated modal-backdrop styles and switch modals to fixed positioning

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ce592d11c832b9e7bdf857c5ba4d1