### PR TITLE
Close modals after form submissions

### DIFF
--- a/js/joinus.js
+++ b/js/joinus.js
@@ -103,6 +103,7 @@ function initJoinForm(root) {
       const inputsContainer = section.querySelector('.inputs');
       inputsContainer.innerHTML = '';
     });
+    window.dispatchEvent(new Event('modal-close'));
   });
 }
 

--- a/js/modals.js
+++ b/js/modals.js
@@ -109,6 +109,7 @@ function openContactModal() {
           }
           alert('Contact form submitted!');
           form.reset();
+          window.dispatchEvent(new Event('modal-close'));
         });
       }
       if (typeof makeDraggable === 'function') makeDraggable(modal);


### PR DESCRIPTION
## Summary
- close Contact form modal after successful submission by dispatching `modal-close`
- close Join Us modal after successful submission with same event

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ce598a7d8832b895ff4b8cc60f943