### PR TITLE
feat: add responsive breakpoints for modals

### DIFF
--- a/css/chatbot.css
+++ b/css/chatbot.css
@@ -14,7 +14,7 @@ body{margin:0;display:flex;align-items:center;justify-content:center;height:100v
 body.dark{--clr-bg:var(--clr-bg-dark);--clr-tx:var(--clr-tx-dark)}
 
 /* ---------- CHATBOT ---------- */
-#chatbot-container{width:300px;height:540px;background:#251541;border:2px solid var(--clr-accent);
+#chatbot-container{background:#251541;border:2px solid var(--clr-accent);
   border-radius:18px;box-shadow:0 8px 32px #0006;display:flex;flex-direction:column;overflow:hidden}
 #chatbot-header{display:flex;justify-content:space-between;align-items:center;gap:.5rem;
   background:linear-gradient(135deg,var(--clr-primary) 0%,var(--clr-accent) 100%);
@@ -35,4 +35,6 @@ body.dark{--clr-bg:var(--clr-bg-dark);--clr-tx:var(--clr-tx-dark)}
 #chatbot-send:disabled{background:#555;cursor:not-allowed}
 .human-check{color:#ddd;font-size:.85rem;display:flex;align-items:center;margin-top:.3rem}
 .human-check input{margin-right:.4rem}
-@media(max-width:480px){#chatbot-container{height:75vh;width:90%}}
+
+@media (min-width:769px){#chatbot-container{width:300px;height:540px}}
+@media (max-width:768px){#chatbot-container{width:90%;height:75vh}}

--- a/css/style.css
+++ b/css/style.css
@@ -182,13 +182,10 @@
     .ops-modal, .modal-content, #chatbot-container {
       min-width: 310px;
       max-width: none;
-      width: 80vw;
-      height: 80vh;
       background: #fff;
       color: #1a1930;
       border-radius: 2rem;
       box-shadow: 0 6px 60px #5e24bb25, 0 0 0 2px #fff1;
-      padding: 2.1rem 2.2rem 1.3rem 2.2rem;
       position: absolute;
       left: 50%;
       top: 50%;
@@ -197,6 +194,28 @@
       cursor: default;
       z-index: 2222;
     }
+
+    @media (min-width: 769px) {
+      .ops-modal, .modal-content, #chatbot-container {
+        width: 80vw;
+        height: 80vh;
+        padding: 2.1rem 2.2rem 1.3rem 2.2rem;
+      }
+    }
+
+    @media (max-width: 768px) {
+      .ops-modal, .modal-content, #chatbot-container {
+        width: 95vw;
+        height: 85vh;
+        padding: 1.2rem;
+        font-size: 0.9rem;
+      }
+
+      .modal-title {
+        font-size: 1.1rem;
+      }
+    }
+
     body.dark .ops-modal, body.dark .modal-content, body.dark #chatbot-container {
       background: #251541;
       color: #fafbfe;
@@ -324,16 +343,6 @@
         flex-direction: column;
         gap: 0.8rem;
         align-items: flex-end;
-      }
-
-      /* Modal changes */
-      .ops-modal, .modal-content, #chatbot-container, .modal {
-        padding: 1.2rem;
-        font-size: 0.9rem; /* Adjust base font size for modals on mobile */
-      }
-
-      .modal-title {
-        font-size: 1.1rem;
       }
 
       #chat-log {


### PR DESCRIPTION
## Summary
- add desktop and mobile breakpoints for modal elements
- align chatbot container with new responsive sizing

## Testing
- `npm install puppeteer --no-save` *(fails: 403 Forbidden)*
- `rg "@media \(min-width: 769px\)" -n css/style.css`
- `rg "@media \(min-width:769px\)" -n css/chatbot.css`


------
https://chatgpt.com/codex/tasks/task_e_688ce59d0d14832b8904e694355707db