### PR TITLE
Add theme transitions for navigation bar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -46,6 +46,12 @@
       padding: 1.2rem 2rem;
       font-weight: 600;
       background: transparent;
+      transition: background-color 0.3s, color 0.3s;
+    }
+    .dark .ops-nav {
+      background: #000;
+      color: #fff;
+      transition: background-color 0.3s, color 0.3s;
     }
     .ops-logo {
       font-family: 'Segoe UI', Arial, sans-serif;
@@ -68,8 +74,11 @@
       cursor: pointer;
       padding: 0.15em 0.3em;
       position: relative;
-      transition: color 0.18s;
+      transition: color 0.3s;
       text-decoration: none;
+    }
+    .dark .nav-link {
+      color: #fff;
     }
     .nav-link:hover, .nav-link:focus { color: var(--clr-primary); outline: none; }
     .toggles { display: flex; gap: 0.5rem; }


### PR DESCRIPTION
## Summary
- add smooth color transition to ops-nav for light and dark themes
- ensure nav links inherit theme colors and transition smoothly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e4b43e270832ba46c4cb88f92a8e0