### PR TITLE
feat: Add shining squircle effect to cards

### DIFF
--- a/css/shining-effect.css
+++ b/css/shining-effect.css
@@ -1,0 +1,123 @@
+body {
+    animation: background-transition 15s ease-in-out infinite;
+}
+
+@keyframes background-transition {
+    0% {
+        background: linear-gradient(135deg, #f2f6fa 0%, #dde3fa 100%);
+    }
+    25% {
+        background: linear-gradient(135deg, #e3f7f7 0%, #d5e3f2 100%);
+    }
+    50% {
+        background: linear-gradient(135deg, #f5e3f7 0%, #f2d5e3 100%);
+    }
+    75% {
+        background: linear-gradient(135deg, #f7f5e3 0%, #e3f2d5 100%);
+    }
+    100% {
+        background: linear-gradient(135deg, #f2f6fa 0%, #dde3fa 100%);
+    }
+}
+
+.card {
+    --squircle: 40px;
+    -webkit-tap-highlight-color: transparent;
+    cursor: pointer;
+    appearance: none;
+    outline: none;
+    border: none;
+    font-family: inherit;
+    background: none;
+    font-size: 16px;
+    font-weight: 500;
+    position: relative;
+    border-radius: calc(var(--squircle) * .45);
+}
+
+.card span {
+    background-image: linear-gradient(90deg, #fcecfe, #fbf6e7, #e6fcf5);
+    padding: 12px 24px;
+    position: relative;
+    line-height: 24px;
+    color: #14387e;
+    display: block;
+    box-shadow: 0 1px 2px rgba(0 0 0 / 2%), 0 4px 16px rgba(0 0 0 / 2%),
+        0 4px 24px rgba(0 0 0 / 2%);
+
+    clip-path: shape(
+        from 0 var(--squircle),
+        curve to var(--squircle) 0 with 0 0 / 0 0,
+        hline to calc(100% - var(--squircle)),
+        curve to 100% var(--squircle) with 100% 0 / 100% 0,
+        vline to calc(100% - var(--squircle)),
+        curve to calc(100% - var(--squircle)) 100% with 100% 100% / 100% 100%,
+        hline to var(--squircle),
+        curve to 0 calc(100% - var(--squircle)) with 0 100% / 0 100%,
+        close
+    );
+}
+
+.card.start .lines svg {
+    animation: stroke 1s linear;
+}
+
+.card .lines {
+    position: absolute;
+    inset: 0;
+    mix-blend-mode: hard-light;
+    pointer-events: none;
+    z-index: 1;
+    transform: scaleX(.92) scaleY(.95) translateZ(0);
+}
+
+.card .lines > div {
+    position: absolute;
+    inset: 0;
+}
+
+.card .lines > div:last-child {
+    transform: rotate(180deg);
+}
+
+.card .lines svg {
+    display: block;
+    position: absolute;
+    inset: 0;
+    overflow: visible;
+    fill: none;
+    stroke-width: 1;
+    stroke: #c9e9ff;
+    width: 100%;
+    height: 100%;
+    stroke-dasharray: 2 10;
+    stroke-dashoffset: 14;
+    opacity: 0;
+}
+
+.card .lines svg:nth-child(1) {
+    stroke: #f8fcff;
+}
+.card .lines svg:nth-child(2) {
+    stroke-width: 6px;
+    filter: blur(20px);
+}
+.card .lines svg:nth-child(3) {
+    stroke-width: 5px;
+    filter: blur(6px);
+}
+.card .lines svg:nth-child(4) {
+    stroke-width: 10px;
+    filter: blur(56px);
+}
+
+@keyframes stroke {
+    30%,
+    55% {
+        opacity: 1;
+    }
+    100% {
+        stroke-dashoffset: 4;
+        opacity: 0;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
       integrity="sha512-bNDdB2S/bRMyCV2wAPOQgpdnH3UX0DpD+s/COM24kTx5cDIeEJD7BqXc9EjoP6KDAdAm8YGtS+wGGyRyvCb4TQ=="
       crossorigin="anonymous" referrerpolicy="no-referrer">
     <link rel="stylesheet" href="css/style.css">
+    <link rel="stylesheet" href="css/shining-effect.css">
     <link rel="stylesheet" href="css/mobile-nav.css">
     <link rel="stylesheet" href="css/center.css">
   </head>
@@ -57,5 +58,6 @@
   <script src="js/load-mobile-nav.js" defer></script>
   <script src="js/main.js" defer></script>
   <script src="js/mobile-nav.js" defer></script>
+  <script src="js/shining-effect.js" defer></script>
 </body>
 </html>

--- a/js/homepage.js
+++ b/js/homepage.js
@@ -5,9 +5,11 @@ function renderCards() {
     const el = document.getElementById('card-'+key);
     if (el && c) {
       el.innerHTML = `
-        <div class="title">${c.title}</div>
-        <div class="icon">${c.icon}</div>
-        <div class="content"><p>${c.desc}</p></div>
+        <span>
+            <div class="title">${c.title}</div>
+            <div class="icon">${c.icon}</div>
+            <div class="content"><p>${c.desc}</p></div>
+        </span>
       `;
     }
   });

--- a/js/shining-effect.js
+++ b/js/shining-effect.js
@@ -1,0 +1,66 @@
+const createSVG = (width, height, radius) => {
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+
+    const rectangle = document.createElementNS(
+        "http://www.w3.org/2000/svg",
+        "rect"
+    );
+
+    svg.setAttributeNS(
+        "http://www.w3.org/2000/svg",
+        "viewBox",
+        `0 0 ${width} ${height}`
+    );
+
+    rectangle.setAttribute("x", "0");
+    rectangle.setAttribute("y", "0");
+    rectangle.setAttribute("width", "100%");
+    rectangle.setAttribute("height", "100%");
+    rectangle.setAttribute("rx", `${radius}`);
+    rectangle.setAttribute("ry", `${radius}`);
+    rectangle.setAttribute("pathLength", "10");
+
+    svg.appendChild(rectangle);
+
+    return svg;
+};
+
+document.querySelectorAll(".card").forEach((card) => {
+    const style = getComputedStyle(card);
+
+    const lines = document.createElement("div");
+
+    lines.classList.add("lines");
+
+    const groupTop = document.createElement("div");
+    const groupBottom = document.createElement("div");
+
+    const svg = createSVG(
+        card.offsetWidth,
+        card.offsetHeight,
+        parseInt(style.borderRadius, 10)
+    );
+
+    groupTop.appendChild(svg);
+    groupTop.appendChild(svg.cloneNode(true));
+    groupTop.appendChild(svg.cloneNode(true));
+    groupTop.appendChild(svg.cloneNode(true));
+
+    groupBottom.appendChild(svg.cloneNode(true));
+    groupBottom.appendChild(svg.cloneNode(true));
+    groupBottom.appendChild(svg.cloneNode(true));
+    groupBottom.appendChild(svg.cloneNode(true));
+
+    lines.appendChild(groupTop);
+    lines.appendChild(groupBottom);
+
+    card.appendChild(lines);
+
+    card.addEventListener("pointerenter", () => {
+        card.classList.add("start");
+    });
+
+    svg.addEventListener("animationend", () => {
+        card.classList.remove("start");
+    });
+});


### PR DESCRIPTION
This commit implements a shining squircle effect on the cards of the homepage, inspired by the provided CodePen example.

The changes include:
- A new CSS file `css/shining-effect.css` with styles for a transitioning background and the shining card effect.
- A new JavaScript file `js/shining-effect.js` that dynamically creates SVG elements to produce the shining lines on hover.
- Modifications to `index.html` to link the new CSS and JavaScript files.
- An update to `js/homepage.js` to wrap the card content in a `<span>` to support the new styling.