### PR TITLE
feat: add reusable theme and language toggles

### DIFF
--- a/chatbot.html
+++ b/chatbot.html
@@ -65,6 +65,7 @@
 <script src="js/i18n.js" defer></script>
 <script src="js/chatbot.js" defer></script>
 <script src="js/load-mobile-nav.js" defer></script>
+<script src="js/toggle-utils.js" defer></script>
 <script src="js/main.js" defer></script>
 <script src="js/mobile-nav.js" defer></script>
 </body>

--- a/contact.html
+++ b/contact.html
@@ -90,6 +90,7 @@
 <script src="js/contactus.js" defer></script>
 <script src="js/i18n.js" defer></script>
 <script src="js/load-mobile-nav.js" defer></script>
+<script src="js/toggle-utils.js" defer></script>
 <script src="js/main.js" defer></script>
 <script src="js/mobile-nav.js" defer></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -56,6 +56,7 @@
   <script src="js/homepage.js" defer></script>
   <script src="js/i18n.js" defer></script>
   <script src="js/load-mobile-nav.js" defer></script>
+  <script src="js/toggle-utils.js" defer></script>
   <script src="js/main.js" defer></script>
   <script src="js/mobile-nav.js" defer></script>
   <script src="js/shining-effect.js" defer></script>

--- a/join.html
+++ b/join.html
@@ -136,6 +136,7 @@
 <script src="js/joinus.js" defer></script>
 <script src="js/i18n.js" defer></script>
 <script src="js/load-mobile-nav.js" defer></script>
+<script src="js/toggle-utils.js" defer></script>
 <script src="js/main.js" defer></script>
 <script src="js/mobile-nav.js" defer></script>
 <script>

--- a/js/main.js
+++ b/js/main.js
@@ -1,32 +1,19 @@
 document.addEventListener('DOMContentLoaded', () => {
   const langToggle = document.getElementById('lang-toggle');
   const themeToggle = document.getElementById('theme-toggle');
-  const savedTheme = localStorage.getItem('theme') || 'light';
-  document.body.classList.toggle('dark', savedTheme === 'dark');
-  if (themeToggle) themeToggle.textContent = savedTheme === 'dark' ? 'Light' : 'Dark';
-  themeToggle && themeToggle.addEventListener('click', () => {
-    const isDark = document.body.classList.toggle('dark');
-    localStorage.setItem('theme', isDark ? 'dark' : 'light');
-    themeToggle.textContent = isDark ? 'Light' : 'Dark';
-  });
+  const langStatus = document.getElementById('lang-status');
 
-  if (langToggle) {
-    let currentLang = typeof lang !== 'undefined' ? lang : 'en';
-    const updateToggle = (l) => {
-      langToggle.textContent = l === 'en' ? 'ES' : 'EN';
-      langToggle.setAttribute('aria-pressed', l === 'es');
-      langToggle.setAttribute('aria-label', l === 'en' ? 'Switch to Spanish' : 'Switch to English');
-      const status = document.getElementById('lang-status');
-      if (status) status.textContent = l === 'en' ? 'English selected' : 'Spanish selected';
-    };
-    updateToggle(currentLang);
-    langToggle.addEventListener('click', () => {
-      const targetLang = currentLang === 'en' ? 'es' : 'en';
-      if (typeof switchLanguage === 'function') {
-        switchLanguage(targetLang);
-      }
-      currentLang = targetLang;
-      updateToggle(currentLang);
+  if (themeToggle && typeof initTheme === 'function') {
+    initTheme({ button: themeToggle });
+  }
+
+  if (langToggle && typeof initLanguage === 'function') {
+    const currentLang = typeof lang !== 'undefined' ? lang : 'en';
+    initLanguage({
+      button: langToggle,
+      statusEl: langStatus,
+      currentLang,
+      onSwitch: typeof switchLanguage === 'function' ? switchLanguage : undefined
     });
   }
 

--- a/js/toggle-utils.js
+++ b/js/toggle-utils.js
@@ -1,0 +1,108 @@
+(function(global){
+  function toggleTheme({
+    button,
+    darkClass = 'dark',
+    storageKey = 'theme',
+    lightLabel = 'Light',
+    darkLabel = 'Dark'
+  } = {}) {
+    const isDark = document.body.classList.toggle(darkClass);
+    try {
+      localStorage.setItem(storageKey, isDark ? 'dark' : 'light');
+    } catch (e) {}
+    if (button) {
+      button.textContent = isDark ? lightLabel : darkLabel;
+    }
+    return isDark ? 'dark' : 'light';
+  }
+
+  function initTheme({
+    button,
+    darkClass = 'dark',
+    storageKey = 'theme',
+    lightLabel = 'Light',
+    darkLabel = 'Dark'
+  } = {}) {
+    const saved = localStorage.getItem(storageKey) || 'light';
+    document.body.classList.toggle(darkClass, saved === 'dark');
+    if (button) {
+      button.textContent = saved === 'dark' ? lightLabel : darkLabel;
+      button.addEventListener('click', () =>
+        toggleTheme({ button, darkClass, storageKey, lightLabel, darkLabel })
+      );
+    }
+    return saved;
+  }
+
+  function toggleLanguage({
+    button,
+    statusEl,
+    currentLang = 'en',
+    onSwitch,
+    labels = { en: 'ES', es: 'EN' },
+    statusMsg = { en: 'English selected', es: 'Spanish selected' }
+  } = {}) {
+    const nextLang = currentLang === 'en' ? 'es' : 'en';
+    if (typeof onSwitch === 'function') {
+      onSwitch(nextLang);
+    }
+    if (button) {
+      button.textContent = labels[nextLang];
+      button.setAttribute('aria-pressed', nextLang === 'es');
+      button.setAttribute(
+        'aria-label',
+        nextLang === 'en' ? 'Switch to Spanish' : 'Switch to English'
+      );
+    }
+    if (statusEl) {
+      statusEl.textContent = statusMsg[nextLang];
+    }
+    return nextLang;
+  }
+
+  function initLanguage({
+    button,
+    statusEl,
+    currentLang = 'en',
+    onSwitch,
+    labels,
+    statusMsg
+  } = {}) {
+    if (button) {
+      const btnLabels = labels || { en: 'ES', es: 'EN' };
+      const messages = statusMsg || {
+        en: 'English selected',
+        es: 'Spanish selected'
+      };
+      button.textContent = btnLabels[currentLang];
+      button.setAttribute('aria-pressed', currentLang === 'es');
+      button.setAttribute(
+        'aria-label',
+        currentLang === 'en' ? 'Switch to Spanish' : 'Switch to English'
+      );
+      if (statusEl) {
+        statusEl.textContent = messages[currentLang];
+      }
+      button.addEventListener('click', () => {
+        currentLang = toggleLanguage({
+          button,
+          statusEl,
+          currentLang,
+          onSwitch,
+          labels: btnLabels,
+          statusMsg: messages
+        });
+      });
+    }
+    return currentLang;
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { toggleTheme, initTheme, toggleLanguage, initLanguage };
+  } else {
+    global.toggleTheme = toggleTheme;
+    global.initTheme = initTheme;
+    global.toggleLanguage = toggleLanguage;
+    global.initLanguage = initLanguage;
+  }
+})(typeof window !== 'undefined' ? window : this);

--- a/mainnav/center.html
+++ b/mainnav/center.html
@@ -130,6 +130,7 @@
   <script src="../js/load-mobile-nav.js" defer></script>
   <script src="../js/form-utils.js" defer></script>
   <script src="../js/i18n.js" defer></script>
+  <script src="../js/toggle-utils.js" defer></script>
   <script src="../js/main.js" defer></script>
   <script src="../js/page-init.js" defer></script>
 </body>

--- a/mainnav/it.html
+++ b/mainnav/it.html
@@ -110,6 +110,7 @@
   <script src="../js/load-mobile-nav.js"></script>
   <script src="../js/form-utils.js"></script>
   <script src="../js/i18n.js"></script>
+  <script src="../js/toggle-utils.js"></script>
   <script src="../js/main.js"></script>
   <script src="../js/page-init.js"></script>
 </body>

--- a/mainnav/opera.html
+++ b/mainnav/opera.html
@@ -124,6 +124,7 @@
   <script src="../js/load-mobile-nav.js" defer></script>
   <script src="../js/form-utils.js" defer></script>
   <script src="../js/i18n.js" defer></script>
+  <script src="../js/toggle-utils.js" defer></script>
   <script src="../js/main.js" defer></script>
   <script src="../js/page-init.js" defer></script>
 </body>

--- a/mainnav/pros.html
+++ b/mainnav/pros.html
@@ -124,6 +124,7 @@
   <script src="../js/load-mobile-nav.js" defer></script>
   <script src="../js/form-utils.js" defer></script>
   <script src="../js/i18n.js" defer></script>
+  <script src="../js/toggle-utils.js" defer></script>
   <script src="../js/main.js" defer></script>
   <script src="../js/page-init.js" defer></script>
 </body>

--- a/service.html
+++ b/service.html
@@ -57,6 +57,7 @@
 <script src="js/i18n.js" defer></script>
 <script src="js/service.js" defer></script>
 <script src="js/load-mobile-nav.js" defer></script>
+<script src="js/toggle-utils.js" defer></script>
 <script src="js/main.js" defer></script>
 <script src="js/mobile-nav.js" defer></script>
 </body>


### PR DESCRIPTION
## Summary
- add configurable `toggleTheme` and `toggleLanguage` utilities
- refactor `main.js` to use new init functions for theme and language toggling
- include utility script across pages for reuse

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e8d3234f0832bacc2c2c749bc8ec7