### PR TITLE
refactor: migrate scripts to es modules

### DIFF
--- a/chatbot.html
+++ b/chatbot.html
@@ -62,10 +62,10 @@
   </div>
 </main>
 <footer>© 2025 OPS Online Support</footer>
-<script src="js/i18n.js" defer></script>
-<script src="js/chatbot.js" defer></script>
-<script src="js/load-mobile-nav.js" defer></script>
-<script src="js/main.js" defer></script>
-<script src="js/mobile-nav.js" defer></script>
+<script type="module" src="js/i18n.js"></script>
+<script type="module" src="js/chatbot.js"></script>
+<script type="module" src="js/load-mobile-nav.js"></script>
+<script type="module" src="js/main.js"></script>
+<script type="module" src="js/mobile-nav.js"></script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -86,11 +86,10 @@
   </form>
 </main>
 <footer>© 2025 OPS Online Support</footer>
-<script src="js/form-utils.js" defer></script>
-<script src="js/contactus.js" defer></script>
-<script src="js/i18n.js" defer></script>
-<script src="js/load-mobile-nav.js" defer></script>
-<script src="js/main.js" defer></script>
-<script src="js/mobile-nav.js" defer></script>
+<script type="module" src="js/contactus.js"></script>
+<script type="module" src="js/i18n.js"></script>
+<script type="module" src="js/load-mobile-nav.js"></script>
+<script type="module" src="js/main.js"></script>
+<script type="module" src="js/mobile-nav.js"></script>
 </body>
 </html>

--- a/fabs/chatbot.html
+++ b/fabs/chatbot.html
@@ -54,7 +54,7 @@
 </div>
 
 <!-- ---------- CHATBOT LOGIC ---------- -->
-<script src="../js/i18n.js"></script>
-<script src="../js/chatbot.js"></script>
+<script type="module" src="../js/i18n.js"></script>
+<script type="module" src="../js/chatbot.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -53,11 +53,11 @@
   <footer>
     © 2025 OPS Online Support
   </footer>
-  <script src="js/homepage.js" defer></script>
-  <script src="js/i18n.js" defer></script>
-  <script src="js/load-mobile-nav.js" defer></script>
-  <script src="js/main.js" defer></script>
-  <script src="js/mobile-nav.js" defer></script>
-  <script src="js/shining-effect.js" defer></script>
+  <script type="module" src="js/homepage.js"></script>
+  <script type="module" src="js/i18n.js"></script>
+  <script type="module" src="js/load-mobile-nav.js"></script>
+  <script type="module" src="js/main.js"></script>
+  <script type="module" src="js/mobile-nav.js"></script>
+  <script type="module" src="js/shining-effect.js"></script>
 </body>
 </html>

--- a/join.html
+++ b/join.html
@@ -132,16 +132,10 @@
   </form>
 </main>
 <footer>© 2025 OPS Online Support</footer>
-<script src="js/form-utils.js" defer></script>
-<script src="js/joinus.js" defer></script>
-<script src="js/i18n.js" defer></script>
-<script src="js/load-mobile-nav.js" defer></script>
-<script src="js/main.js" defer></script>
-<script src="js/mobile-nav.js" defer></script>
-<script>
-  document.addEventListener('DOMContentLoaded', () => {
-    initJoinForm(document);
-  });
-</script>
+<script type="module" src="js/joinus.js"></script>
+<script type="module" src="js/i18n.js"></script>
+<script type="module" src="js/load-mobile-nav.js"></script>
+<script type="module" src="js/main.js"></script>
+<script type="module" src="js/mobile-nav.js"></script>
 </body>
 </html>

--- a/js/chatbot.js
+++ b/js/chatbot.js
@@ -1,3 +1,5 @@
+import { switchLanguage } from './i18n.js';
+
 const qs=s=>document.querySelector(s);
 
 /* === Language toggle === */

--- a/js/contactus.js
+++ b/js/contactus.js
@@ -1,9 +1,10 @@
+import { sanitizeForm } from './form-utils.js';
+
 document.addEventListener('DOMContentLoaded', () => {
   const contactForm = document.getElementById('contactForm');
-  const sanitize = window.sanitizeForm;
   contactForm.addEventListener('submit', e => {
     e.preventDefault();
-    if (typeof sanitize === 'function' && !sanitize(contactForm)) {
+    if (!sanitizeForm(contactForm)) {
       alert('Suspicious content detected. Submission rejected.');
       return;
     }

--- a/js/form-utils.js
+++ b/js/form-utils.js
@@ -1,18 +1,11 @@
-(function(global){
-  function sanitizeForm(form) {
-    const fields = form.querySelectorAll('input, textarea');
-    for (const field of fields) {
-      const val = field.value.trim();
-      if (/[<>]/.test(val) || /script/i.test(val)) {
-        return false;
-      }
-      field.value = val;
+export function sanitizeForm(form) {
+  const fields = form.querySelectorAll('input, textarea');
+  for (const field of fields) {
+    const val = field.value.trim();
+    if (/[<>]/.test(val) || /script/i.test(val)) {
+      return false;
     }
-    return true;
+    field.value = val;
   }
-  if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { sanitizeForm };
-  } else {
-    global.sanitizeForm = sanitizeForm;
-  }
-})(typeof window !== 'undefined' ? window : this);
+  return true;
+}

--- a/js/homepage.js
+++ b/js/homepage.js
@@ -1,4 +1,5 @@
-let svc = {};
+import { svc } from './i18n.js';
+
 function renderCards() {
   ['ops','cc','it','pro'].forEach(key => {
     const c = svc[key];
@@ -22,3 +23,5 @@ function renderCards() {
     card.onkeydown = e => { if (e.key === 'Enter' || e.key === ' ') go(); };
   }
 });
+
+document.addEventListener('translations-applied', renderCards);

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -1,6 +1,7 @@
-var lang = 'en';
-var translations = {};
+let lang = 'en';
+const translations = {};
 const fallbackLang = { svc: {} };
+export let svc = {};
 
 function sanitizeHTML(html) {
   const template = document.createElement('template');
@@ -70,9 +71,9 @@ function applyTranslations() {
     key.forEach(k => { if (text) text = text[k]; });
     if (text) el.setAttribute('alt', text);
   });
-  if (typeof renderCards === 'function') renderCards();
+  document.dispatchEvent(new Event('translations-applied'));
 }
-function switchLanguage(l) {
+export function switchLanguage(l) {
   lang = l;
   localStorage.setItem('lang', l);
   const toggle = document.getElementById('lang-toggle');
@@ -90,6 +91,10 @@ function switchLanguage(l) {
       translations[l] = fallbackLang;
       applyTranslations();
     });
+}
+
+export function getCurrentLang() {
+  return lang;
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/js/joinus.js
+++ b/js/joinus.js
@@ -1,5 +1,6 @@
-function initJoinForm(root) {
-  root = root || document;
+import { sanitizeForm } from './form-utils.js';
+
+export function initJoinForm(root = document) {
   const joinForm = root.querySelector('#joinForm');
   if (!joinForm) return;
 
@@ -82,7 +83,7 @@ function initJoinForm(root) {
 
   joinForm.addEventListener('submit', e => {
     e.preventDefault();
-    if (!window.sanitizeForm(joinForm)) {
+    if (!sanitizeForm(joinForm)) {
       alert('Suspicious content detected. Submission rejected.');
       return;
     }
@@ -107,4 +108,6 @@ function initJoinForm(root) {
   });
 }
 
-window.initJoinForm = initJoinForm;
+document.addEventListener('DOMContentLoaded', () => {
+  initJoinForm(document);
+});

--- a/js/load-mobile-nav.js
+++ b/js/load-mobile-nav.js
@@ -1,33 +1,32 @@
-(function () {
-  const base = window.location.pathname.includes('/mainnav/') ? '..' : '.';
+import { initMobileNav } from './mobile-nav.js';
 
-  function appendToBody(html) {
-    if (html && html.trim()) {
-      document.body.insertAdjacentHTML('beforeend', html);
-    }
+const base = window.location.pathname.includes('/mainnav/') ? '..' : '.';
+
+function appendToBody(html) {
+  if (html && html.trim()) {
+    document.body.insertAdjacentHTML('beforeend', html);
   }
+}
 
-  function loadMobileNav() {
-    return fetch(`${base}/fabs/mobile-nav.html`)
-      .then((r) => {
-        if (!r.ok) {
-          throw new Error(`mobile-nav.html ${r.status} ${r.statusText}`);
-        }
-        return r.text();
-      })
-      .then((html) => {
-        if (html.trim()) {
-          appendToBody(html);
-          if (typeof window.initMobileNav === 'function') {
-            window.initMobileNav();
-          }
-        }
-      })
-      .catch((err) => console.error('mobile-nav fetch error:', err));
-  }
+function loadMobileNav() {
+  return fetch(`${base}/fabs/mobile-nav.html`)
+    .then((r) => {
+      if (!r.ok) {
+        throw new Error(`mobile-nav.html ${r.status} ${r.statusText}`);
+      }
+      return r.text();
+    })
+    .then((html) => {
+      if (html.trim()) {
+        appendToBody(html);
+        initMobileNav();
+      }
+    })
+    .catch((err) => console.error('mobile-nav fetch error:', err));
+}
 
-  if (window.location.protocol === 'file:') {
-    const mobileNavHTML = `<div id="mobileNav" class="mobile-nav" aria-label="Mobile navigation">
+if (window.location.protocol === 'file:') {
+  const mobileNavHTML = `<div id="mobileNav" class="mobile-nav" aria-label="Mobile navigation">
   <div class="nav-items">
     <a href="${base}/contact.html?ref=mobile" class="nav-btn" title="Contact Us" aria-label="Contact Us"><i class="fa-solid fa-envelope"></i></a>
     <a href="${base}/join.html?ref=mobile" class="nav-btn" title="Join Us" aria-label="Join Us"><i class="fa-solid fa-user-plus"></i></a>
@@ -49,12 +48,9 @@
     <i class="fa-solid fa-bars" aria-hidden="true"></i>
   </button>
 </div>`;
-    appendToBody(mobileNavHTML);
-    if (typeof window.initMobileNav === 'function') {
-      window.initMobileNav();
-    }
-  } else {
-    loadMobileNav();
-  }
-})();
+  appendToBody(mobileNavHTML);
+  initMobileNav();
+} else {
+  loadMobileNav();
+}
 

--- a/js/main.js
+++ b/js/main.js
@@ -1,3 +1,5 @@
+import { switchLanguage, getCurrentLang } from './i18n.js';
+
 document.addEventListener('DOMContentLoaded', () => {
   const langToggle = document.getElementById('lang-toggle');
   const themeToggle = document.getElementById('theme-toggle');
@@ -11,7 +13,7 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   if (langToggle) {
-    let currentLang = typeof lang !== 'undefined' ? lang : 'en';
+    let currentLang = getCurrentLang();
     const updateToggle = (l) => {
       langToggle.textContent = l === 'en' ? 'ES' : 'EN';
       langToggle.setAttribute('aria-pressed', l === 'es');
@@ -22,9 +24,7 @@ document.addEventListener('DOMContentLoaded', () => {
     updateToggle(currentLang);
     langToggle.addEventListener('click', () => {
       const targetLang = currentLang === 'en' ? 'es' : 'en';
-      if (typeof switchLanguage === 'function') {
-        switchLanguage(targetLang);
-      }
+      switchLanguage(targetLang);
       currentLang = targetLang;
       updateToggle(currentLang);
     });

--- a/js/mobile-nav.js
+++ b/js/mobile-nav.js
@@ -1,4 +1,4 @@
-function initMobileNav() {
+export function initMobileNav() {
   const mobileNav = document.getElementById('mobileNav');
   const toggleNav = document.getElementById('toggleNav');
   const svcBtn = document.getElementById('svcBtn');
@@ -79,5 +79,3 @@ function initMobileNav() {
     svg.addEventListener('animationend', () => button.classList.remove('start'));
   });
 }
-
-window.initMobileNav = initMobileNav;

--- a/js/modals.js
+++ b/js/modals.js
@@ -1,3 +1,6 @@
+import { sanitizeForm } from './form-utils.js';
+import { switchLanguage, getCurrentLang } from './i18n.js';
+
 const mobileNav = document.getElementById('mobileNav');
 const toggleNav = document.getElementById('toggleNav');
 const langBtn = document.getElementById('langBtn');
@@ -51,9 +54,10 @@ if (svcBtn) {
 
 if (langBtn) {
   langBtn.onclick = () => {
-    lang = lang==='en'?'es':'en';
-    langBtn.textContent = lang==='en'?'ES':'EN';
-    document.documentElement.lang = lang;
+    const current = getCurrentLang();
+    const newLang = current === 'en' ? 'es' : 'en';
+    switchLanguage(newLang);
+    langBtn.textContent = newLang === 'en' ? 'ES' : 'EN';
   };
 }
 
@@ -252,18 +256,7 @@ function openJoinModal() {
       window.addEventListener('modal-close', close, { once: true });
       detach = attachModalClose(modal, close);
 
-      function init() {
-        if (typeof initJoinForm === 'function') initJoinForm(modal);
-      }
-
-      if (typeof initJoinForm === 'function') {
-        init();
-      } else {
-        const script = document.createElement('script');
-        script.src = `${base}/js/joinus.js`;
-        script.onload = init;
-        document.head.appendChild(script);
-      }
+      import('./joinus.js').then(m => m.initJoinForm(modal));
 
       if (typeof makeDraggable === 'function') makeDraggable(modal);
     })

--- a/js/page-init.js
+++ b/js/page-init.js
@@ -1,9 +1,11 @@
+import { sanitizeForm } from './form-utils.js';
+
 document.addEventListener('DOMContentLoaded', () => {
   const form = document.querySelector('#form form');
   if (!form) return;
   form.addEventListener('submit', e => {
     e.preventDefault();
-    if (typeof sanitizeForm === 'function' && !sanitizeForm(form)) {
+    if (!sanitizeForm(form)) {
       alert('Suspicious content detected. Submission rejected.');
       return;
     }

--- a/js/service.js
+++ b/js/service.js
@@ -1,3 +1,5 @@
+import { svc } from './i18n.js';
+
 document.addEventListener('DOMContentLoaded', () => {
   const params = new URLSearchParams(window.location.search);
   const key = params.get('svc');

--- a/mainnav/center.html
+++ b/mainnav/center.html
@@ -127,10 +127,9 @@
       <button type="submit" data-i18n="form.requestQuote">Request Quote</button>
     </form>
   </section>
-  <script src="../js/load-mobile-nav.js" defer></script>
-  <script src="../js/form-utils.js" defer></script>
-  <script src="../js/i18n.js" defer></script>
-  <script src="../js/main.js" defer></script>
-  <script src="../js/page-init.js" defer></script>
+  <script type="module" src="../js/load-mobile-nav.js"></script>
+  <script type="module" src="../js/i18n.js"></script>
+  <script type="module" src="../js/main.js"></script>
+  <script type="module" src="../js/page-init.js"></script>
 </body>
 </html>

--- a/mainnav/it.html
+++ b/mainnav/it.html
@@ -107,10 +107,9 @@
       <button type="submit" data-i18n="form.requestQuote">Request Quote</button>
     </form>
   </section>
-  <script src="../js/load-mobile-nav.js"></script>
-  <script src="../js/form-utils.js"></script>
-  <script src="../js/i18n.js"></script>
-  <script src="../js/main.js"></script>
-  <script src="../js/page-init.js"></script>
+  <script type="module" src="../js/load-mobile-nav.js"></script>
+  <script type="module" src="../js/i18n.js"></script>
+  <script type="module" src="../js/main.js"></script>
+  <script type="module" src="../js/page-init.js"></script>
 </body>
 </html>

--- a/mainnav/opera.html
+++ b/mainnav/opera.html
@@ -121,10 +121,9 @@
     </form>
   </section>
   </main>
-  <script src="../js/load-mobile-nav.js" defer></script>
-  <script src="../js/form-utils.js" defer></script>
-  <script src="../js/i18n.js" defer></script>
-  <script src="../js/main.js" defer></script>
-  <script src="../js/page-init.js" defer></script>
+  <script type="module" src="../js/load-mobile-nav.js"></script>
+  <script type="module" src="../js/i18n.js"></script>
+  <script type="module" src="../js/main.js"></script>
+  <script type="module" src="../js/page-init.js"></script>
 </body>
 </html>

--- a/mainnav/pros.html
+++ b/mainnav/pros.html
@@ -121,10 +121,9 @@
       <button type="submit" data-i18n="form.requestQuote">Request Quote</button>
     </form>
   </section>
-  <script src="../js/load-mobile-nav.js" defer></script>
-  <script src="../js/form-utils.js" defer></script>
-  <script src="../js/i18n.js" defer></script>
-  <script src="../js/main.js" defer></script>
-  <script src="../js/page-init.js" defer></script>
+  <script type="module" src="../js/load-mobile-nav.js"></script>
+  <script type="module" src="../js/i18n.js"></script>
+  <script type="module" src="../js/main.js"></script>
+  <script type="module" src="../js/page-init.js"></script>
 </body>
 </html>

--- a/service.html
+++ b/service.html
@@ -54,10 +54,10 @@
   </div>
 </main>
 <footer>© 2025 OPS Online Support</footer>
-<script src="js/i18n.js" defer></script>
-<script src="js/service.js" defer></script>
-<script src="js/load-mobile-nav.js" defer></script>
-<script src="js/main.js" defer></script>
-<script src="js/mobile-nav.js" defer></script>
+<script type="module" src="js/i18n.js"></script>
+<script type="module" src="js/service.js"></script>
+<script type="module" src="js/load-mobile-nav.js"></script>
+<script type="module" src="js/main.js"></script>
+<script type="module" src="js/mobile-nav.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- convert utility scripts to ES modules and expose shared functions
- update dependent scripts to import exports instead of relying on globals
- mark HTML script tags as module for modern loading

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e8d34ef70832b82e6376738a4f5f0