### PR TITLE
feat: harden form validation

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -5,7 +5,7 @@
 <meta name="description" content="Contact OPS Online Support with inquiries or service requests using this form." />
 <meta name="robots" content="index, follow" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
-<meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' https://cdnjs.cloudflare.com; script-src 'self'; font-src 'self' https://cdnjs.cloudflare.com; img-src 'self' data: https://placehold.co;">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' https://cdnjs.cloudflare.com; script-src 'self' https://cdn.jsdelivr.net; font-src 'self' https://cdnjs.cloudflare.com; img-src 'self' data: https://placehold.co;">
 <meta http-equiv="Strict-Transport-Security" content="max-age=63072000; includeSubDomains; preload">
 <meta name="referrer" content="no-referrer">
 <meta http-equiv="X-Content-Type-Options" content="nosniff">
@@ -86,6 +86,7 @@
   </form>
 </main>
 <footer>© 2025 OPS Online Support</footer>
+<script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.3/dist/purify.min.js"></script>
 <script src="js/form-utils.js" defer></script>
 <script src="js/contactus.js" defer></script>
 <script src="js/i18n.js" defer></script>

--- a/join.html
+++ b/join.html
@@ -5,7 +5,7 @@
 <meta name="description" content="Join OPS Online Support's community and team through this registration form." />
 <meta name="robots" content="index, follow" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
-<meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' https://cdnjs.cloudflare.com; script-src 'self'; font-src 'self' https://cdnjs.cloudflare.com; img-src 'self' data: https://placehold.co;">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' https://cdnjs.cloudflare.com; script-src 'self' https://cdn.jsdelivr.net; font-src 'self' https://cdnjs.cloudflare.com; img-src 'self' data: https://placehold.co;">
 <meta http-equiv="Strict-Transport-Security" content="max-age=63072000; includeSubDomains; preload">
 <meta name="referrer" content="no-referrer">
 <meta http-equiv="X-Content-Type-Options" content="nosniff">
@@ -132,6 +132,7 @@
   </form>
 </main>
 <footer>© 2025 OPS Online Support</footer>
+<script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.3/dist/purify.min.js"></script>
 <script src="js/form-utils.js" defer></script>
 <script src="js/joinus.js" defer></script>
 <script src="js/i18n.js" defer></script>

--- a/js/contactus.js
+++ b/js/contactus.js
@@ -1,10 +1,25 @@
 document.addEventListener('DOMContentLoaded', () => {
   const contactForm = document.getElementById('contactForm');
   const sanitize = window.sanitizeForm;
+  const validate = window.validateFields;
+  const rules = {
+    name: { maxLength: 50, pattern: /^[a-zA-Z\s'-]+$/ },
+    email: { maxLength: 100, pattern: /^[^@\s]+@[^@\s]+\.[^@\s]+$/ },
+    contactNumber: { maxLength: 20, pattern: /^[0-9+\-\s()]+$/ },
+    preferredDate: { required: true },
+    preferredTime: { required: true },
+    interest: { required: true },
+    comments: { maxLength: 500 }
+  };
+
   contactForm.addEventListener('submit', e => {
     e.preventDefault();
     if (typeof sanitize === 'function' && !sanitize(contactForm)) {
       alert('Suspicious content detected. Submission rejected.');
+      return;
+    }
+    if (typeof validate === 'function' && !validate(contactForm, rules)) {
+      alert('Please correct the highlighted fields.');
       return;
     }
     alert('Contact form submitted!');

--- a/js/form-utils.js
+++ b/js/form-utils.js
@@ -1,18 +1,34 @@
+/* global DOMPurify */
 (function(global){
   function sanitizeForm(form) {
     const fields = form.querySelectorAll('input, textarea');
     for (const field of fields) {
-      const val = field.value.trim();
-      if (/[<>]/.test(val) || /script/i.test(val)) {
+      const original = field.value;
+      const clean = DOMPurify.sanitize(original, { ALLOWED_TAGS: [], ALLOWED_ATTR: [] }).trim();
+      if (clean !== original.trim()) {
         return false;
       }
-      field.value = val;
+      field.value = clean;
     }
     return true;
   }
+
+  function validateFields(form, rules) {
+    for (const [id, rule] of Object.entries(rules)) {
+      const field = form.querySelector(`#${id}`);
+      if (!field) continue;
+      const val = field.value.trim();
+      if (rule.required && !val) return false;
+      if (rule.maxLength && val.length > rule.maxLength) return false;
+      if (rule.pattern && !rule.pattern.test(val)) return false;
+    }
+    return true;
+  }
+
   if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { sanitizeForm };
+    module.exports = { sanitizeForm, validateFields };
   } else {
     global.sanitizeForm = sanitizeForm;
+    global.validateFields = validateFields;
   }
 })(typeof window !== 'undefined' ? window : this);

--- a/js/joinus.js
+++ b/js/joinus.js
@@ -3,6 +3,13 @@ function initJoinForm(root) {
   const joinForm = root.querySelector('#joinForm');
   if (!joinForm) return;
 
+  const rules = {
+    name: { maxLength: 50, pattern: /^[a-zA-Z\s'-]+$/ },
+    email: { maxLength: 100, pattern: /^[^@\s]+@[^@\s]+\.[^@\s]+$/ },
+    phone: { maxLength: 20, pattern: /^[0-9+\-\s()]+$/ },
+    about: { maxLength: 500 }
+  };
+
   function toggleSectionState(section, accepted) {
     const inputs = section.querySelectorAll('input[type=text]');
     const acceptBtn = section.querySelector('.accept-btn');
@@ -41,6 +48,7 @@ function initJoinForm(root) {
         const input = document.createElement('input');
         input.type = 'text';
         input.placeholder = `Enter ${section.querySelector('h2').textContent}`;
+        input.maxLength = 100;
         inputsContainer.appendChild(input);
         input.focus();
       });
@@ -64,8 +72,13 @@ function initJoinForm(root) {
           return;
         }
         for (const input of inputs) {
-          if (!input.value.trim()) {
+          const val = input.value.trim();
+          if (!val) {
             alert('Please fill out all fields before accepting.');
+            return;
+          }
+          if (val.length > 100 || !/^[\w\s.,-]+$/.test(val)) {
+            alert('Entries must be under 100 characters and use only letters, numbers, spaces, commas, periods, or hyphens.');
             return;
           }
         }
@@ -82,9 +95,20 @@ function initJoinForm(root) {
 
   joinForm.addEventListener('submit', e => {
     e.preventDefault();
-    if (!window.sanitizeForm(joinForm)) {
+    if (typeof window.sanitizeForm === 'function' && !window.sanitizeForm(joinForm)) {
       alert('Suspicious content detected. Submission rejected.');
       return;
+    }
+    if (typeof window.validateFields === 'function' && !window.validateFields(joinForm, rules)) {
+      alert('Please correct the highlighted fields.');
+      return;
+    }
+    for (const input of joinForm.querySelectorAll('.form-section input[type=text]')) {
+      const val = input.value.trim();
+      if (val && (val.length > 100 || !/^[\w\s.,-]+$/.test(val))) {
+        alert('Entries must be under 100 characters and use only letters, numbers, spaces, commas, periods, or hyphens.');
+        return;
+      }
     }
 
     for (const section of formSections) {

--- a/js/modals.js
+++ b/js/modals.js
@@ -124,8 +124,21 @@ function openContactModal() {
       if (form) {
         form.addEventListener('submit', e => {
           e.preventDefault();
-          if (!sanitizeForm(form)) {
+          if (typeof sanitizeForm === 'function' && !sanitizeForm(form)) {
             alert('Suspicious content detected. Submission rejected.');
+            return;
+          }
+          const rules = {
+            name: { maxLength: 50, pattern: /^[a-zA-Z\s'-]+$/ },
+            email: { maxLength: 100, pattern: /^[^@\s]+@[^@\s]+\.[^@\s]+$/ },
+            contactNumber: { maxLength: 20, pattern: /^[0-9+\-\s()]+$/ },
+            preferredDate: { required: true },
+            preferredTime: { required: true },
+            interest: { required: true },
+            comments: { maxLength: 500 }
+          };
+          if (typeof validateFields === 'function' && !validateFields(form, rules)) {
+            alert('Please correct the highlighted fields.');
             return;
           }
           alert('Contact form submitted!');

--- a/js/page-init.js
+++ b/js/page-init.js
@@ -1,13 +1,23 @@
 document.addEventListener('DOMContentLoaded', () => {
   const form = document.querySelector('#form form');
   if (!form) return;
+  const rules = {
+    name: { maxLength: 50, pattern: /^[a-zA-Z\s'-]+$/ },
+    email: { maxLength: 100, pattern: /^[^@\s]+@[^@\s]+\.[^@\s]+$/ },
+    contactNumber: { maxLength: 20, pattern: /^[0-9+\-\s()]+$/ }
+  };
   form.addEventListener('submit', e => {
     e.preventDefault();
     if (typeof sanitizeForm === 'function' && !sanitizeForm(form)) {
       alert('Suspicious content detected. Submission rejected.');
       return;
     }
+    if (typeof validateFields === 'function' && !validateFields(form, rules)) {
+      alert('Please correct the highlighted fields.');
+      return;
+    }
     alert('Contact form submitted!');
     form.reset();
   });
 });
+

--- a/mainnav/center.html
+++ b/mainnav/center.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" integrity="sha512-bNDdB2S/bRMyCV2wAPOQgpdnH3UX0DpD+s/COM24kTx5cDIeEJD7BqXc9EjoP6KDAdAm8YGtS+wGGyRyvCb4TQ==" crossorigin="anonymous" referrerpolicy="no-referrer">
 <meta http-equiv="Content-Security-Policy" content="
   default-src 'self';
-  script-src 'self' https://www.gstatic.com https://www.google.com https://challenges.cloudflare.com;
+  script-src 'self' https://cdn.jsdelivr.net https://www.gstatic.com https://www.google.com https://challenges.cloudflare.com;
   style-src 'self' https://fonts.googleapis.com https://cdnjs.cloudflare.com;
   font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com;
   connect-src 'self' https://www.googleapis.com https://api.cloudflare.com;
@@ -128,6 +128,7 @@
     </form>
   </section>
   <script src="../js/load-mobile-nav.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.3/dist/purify.min.js"></script>
   <script src="../js/form-utils.js" defer></script>
   <script src="../js/i18n.js" defer></script>
   <script src="../js/main.js" defer></script>

--- a/mainnav/it.html
+++ b/mainnav/it.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" integrity="sha512-bNDdB2S/bRMyCV2wAPOQgpdnH3UX0DpD+s/COM24kTx5cDIeEJD7BqXc9EjoP6KDAdAm8YGtS+wGGyRyvCb4TQ==" crossorigin="anonymous" referrerpolicy="no-referrer">
 <meta http-equiv="Content-Security-Policy" content="
   default-src 'self';
-  script-src 'self' https://www.gstatic.com https://www.google.com https://challenges.cloudflare.com;
+  script-src 'self' https://cdn.jsdelivr.net https://www.gstatic.com https://www.google.com https://challenges.cloudflare.com;
   style-src 'self' https://fonts.googleapis.com https://cdnjs.cloudflare.com;
   font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com;
   connect-src 'self' https://www.googleapis.com https://api.cloudflare.com;
@@ -108,6 +108,7 @@
     </form>
   </section>
   <script src="../js/load-mobile-nav.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.3/dist/purify.min.js"></script>
   <script src="../js/form-utils.js"></script>
   <script src="../js/i18n.js"></script>
   <script src="../js/main.js"></script>

--- a/mainnav/opera.html
+++ b/mainnav/opera.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" integrity="sha512-bNDdB2S/bRMyCV2wAPOQgpdnH3UX0DpD+s/COM24kTx5cDIeEJD7BqXc9EjoP6KDAdAm8YGtS+wGGyRyvCb4TQ==" crossorigin="anonymous" referrerpolicy="no-referrer">
 <meta http-equiv="Content-Security-Policy" content="
   default-src 'self';
-  script-src 'self' https://www.gstatic.com https://www.google.com https://challenges.cloudflare.com;
+  script-src 'self' https://cdn.jsdelivr.net https://www.gstatic.com https://www.google.com https://challenges.cloudflare.com;
   style-src 'self' https://fonts.googleapis.com https://cdnjs.cloudflare.com;
   font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com;
   connect-src 'self' https://www.googleapis.com https://api.cloudflare.com;
@@ -122,6 +122,7 @@
   </section>
   </main>
   <script src="../js/load-mobile-nav.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.3/dist/purify.min.js"></script>
   <script src="../js/form-utils.js" defer></script>
   <script src="../js/i18n.js" defer></script>
   <script src="../js/main.js" defer></script>

--- a/mainnav/pros.html
+++ b/mainnav/pros.html
@@ -11,7 +11,7 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" integrity="sha512-bNDdB2S/bRMyCV2wAPOQgpdnH3UX0DpD+s/COM24kTx5cDIeEJD7BqXc9EjoP6KDAdAm8YGtS+wGGyRyvCb4TQ==" crossorigin="anonymous" referrerpolicy="no-referrer">
 <meta http-equiv="Content-Security-Policy" content="
   default-src 'self';
-  script-src 'self' https://www.gstatic.com https://www.google.com https://challenges.cloudflare.com;
+  script-src 'self' https://cdn.jsdelivr.net https://www.gstatic.com https://www.google.com https://challenges.cloudflare.com;
   style-src 'self' https://fonts.googleapis.com https://cdnjs.cloudflare.com;
   font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com;
   connect-src 'self' https://www.googleapis.com https://api.cloudflare.com;
@@ -122,6 +122,7 @@
     </form>
   </section>
   <script src="../js/load-mobile-nav.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.3/dist/purify.min.js"></script>
   <script src="../js/form-utils.js" defer></script>
   <script src="../js/i18n.js" defer></script>
   <script src="../js/main.js" defer></script>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "phoenix",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"No tests specified\""
+  },
+  "dependencies": {
+    "dompurify": "^3.0.3",
+    "jsdom": "^24.0.0"
+  }
+}
+

--- a/server/validation.js
+++ b/server/validation.js
@@ -1,0 +1,57 @@
+const { JSDOM } = require('jsdom');
+const createDOMPurify = require('dompurify');
+const window = new JSDOM('').window;
+const DOMPurify = createDOMPurify(window);
+
+function sanitize(value) {
+  return DOMPurify.sanitize(value, { ALLOWED_TAGS: [], ALLOWED_ATTR: [] }).trim();
+}
+
+function validateFields(data, rules) {
+  for (const [key, rule] of Object.entries(rules)) {
+    const val = sanitize(data[key] || '');
+    if (rule.required && !val) return false;
+    if (rule.maxLength && val.length > rule.maxLength) return false;
+    if (rule.pattern && !rule.pattern.test(val)) return false;
+    data[key] = val;
+  }
+  return true;
+}
+
+const contactRules = {
+  name: { maxLength: 50, pattern: /^[a-zA-Z\s'-]+$/ },
+  email: { maxLength: 100, pattern: /^[^@\s]+@[^@\s]+\.[^@\s]+$/ },
+  contactNumber: { maxLength: 20, pattern: /^[0-9+\-\s()]+$/ },
+  preferredDate: { required: true },
+  preferredTime: { required: true },
+  interest: { required: true },
+  comments: { maxLength: 500 }
+};
+
+const joinRules = {
+  name: { maxLength: 50, pattern: /^[a-zA-Z\s'-]+$/ },
+  email: { maxLength: 100, pattern: /^[^@\s]+@[^@\s]+\.[^@\s]+$/ },
+  phone: { maxLength: 20, pattern: /^[0-9+\-\s()]+$/ },
+  about: { maxLength: 500 }
+};
+
+function validateContact(data) {
+  return validateFields(data, contactRules);
+}
+
+function validateJoin(data) {
+  if (!validateFields(data, joinRules)) return false;
+  const arrayFields = ['skills', 'education', 'certification', 'hobbies', 'continuedEducation', 'experience'];
+  for (const key of arrayFields) {
+    if (Array.isArray(data[key])) {
+      for (const item of data[key]) {
+        const val = sanitize(item);
+        if (val.length > 100 || !/^[\w\s.,-]+$/.test(val)) return false;
+      }
+    }
+  }
+  return true;
+}
+
+module.exports = { validateContact, validateJoin };
+


### PR DESCRIPTION
## Summary
- sanitize form inputs with DOMPurify and add reusable field validator
- enforce length and character checks on contact and join forms
- provide server-side validation helpers mirroring client rules

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test`
- `node -e "require('./server/validation')"` *(fails: Cannot find module 'jsdom')*


------
https://chatgpt.com/codex/tasks/task_e_688e8d371d60832ba77108b567ae2fa0