### PR TITLE
style: adjust card dimensions and font

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -147,8 +147,8 @@
       position: relative;
       overflow: hidden;
       cursor: pointer;
-      min-height: 170px;
-      font-size: 0.93em;
+      aspect-ratio: 4 / 3;
+      font-size: 16px;
     }
     .card:hover { transform: translateY(-5px) scale(1.03); box-shadow: 0 4px 32px #ff3bdc22; }
     .card .title {


### PR DESCRIPTION
## Summary
- Ensure home page cards render as rectangles
- Standardize card text sizing to 16px

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e98c8361c832bbcfc1416e9397b06