### PR TITLE
Standardize forms and unify global styling

### DIFF
--- a/chatbot.html
+++ b/chatbot.html
@@ -13,6 +13,7 @@
 <title data-i18n="chatbot.title">OPS AI Chatbot</title>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" integrity="sha512-RXf+QSDCUqpphKAa+WAc3XQ8fE5H1aO/8e2wY+8Q1n8yVwDh1RZTf1TDN8E+u1n7eU5KyY7X2Qo+hqeZZn+UAQ==" crossorigin="anonymous" referrerpolicy="no-referrer">
 <link rel="stylesheet" href="css/style.css">
+<link rel="stylesheet" href="css/shining-effect.css">
 <link rel="stylesheet" href="css/mobile-nav.css">
 <link rel="stylesheet" href="css/center.css">
 <link rel="stylesheet" href="css/chatbot.css">

--- a/contact.html
+++ b/contact.html
@@ -12,10 +12,11 @@
 <meta http-equiv="X-Frame-Options" content="SAMEORIGIN">
 <title>Contact Us - OPS</title>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" integrity="sha512-bNDdB2S/bRMyCV2wAPOQgpdnH3UX0DpD+s/COM24kTx5cDIeEJD7BqXc9EjoP6KDAdAm8YGtS+wGGyRyvCb4TQ==" crossorigin="anonymous" referrerpolicy="no-referrer">
-<link rel="stylesheet" href="css/style.css">
-<link rel="stylesheet" href="css/mobile-nav.css">
-<link rel="stylesheet" href="css/center.css">
-<link rel="stylesheet" href="css/contactus.css">
+  <link rel="stylesheet" href="css/style.css">
+  <link rel="stylesheet" href="css/shining-effect.css">
+  <link rel="stylesheet" href="css/mobile-nav.css">
+  <link rel="stylesheet" href="css/center.css">
+  <link rel="stylesheet" href="css/contactus.css">
 </head>
 <body>
 <nav class="ops-nav" aria-label="OPS Navigation">
@@ -41,29 +42,35 @@
   <form aria-label="Contact form" id="contactForm" autocomplete="off" action="#">
     <div class="form-row">
       <div class="form-cell">
-        <label for="name">Name</label>
-        <input id="name" required placeholder="Enter your name" />
+        <label for="name">Full Name</label>
+        <input id="name" required placeholder="" data-en="Full Name" data-es="Nombre Completo" />
       </div>
       <div class="form-cell">
-        <label for="email">Email</label>
-        <input id="email" type="email" required placeholder="Enter your email" />
+        <label for="email">Business Email</label>
+        <input id="email" type="email" required placeholder="" data-en="Business Email" data-es="Correo Electrónico Empresarial" />
       </div>
     </div>
     <div class="form-row">
       <div class="form-cell">
-        <label for="contactNumber">Contact Number</label>
-        <input id="contactNumber" type="tel" required placeholder="Enter your contact number" />
+        <label for="contactNumber">Your Phone Number</label>
+        <input id="contactNumber" type="tel" required placeholder="" data-en="Your Phone Number" data-es="Su Numero de Telefono" />
       </div>
+      <div class="form-cell">
+        <label for="company">Company</label>
+        <input id="company" type="text" required placeholder="" data-en="Company" data-es="Empresa" />
+      </div>
+    </div>
+    <div class="form-row">
       <div class="form-cell">
         <label for="preferredDate">Preferred Date</label>
         <input id="preferredDate" type="date" required placeholder="Select a date" />
       </div>
-    </div>
-    <div class="form-row">
       <div class="form-cell">
         <label for="preferredTime">Preferred Time</label>
         <input id="preferredTime" type="time" required placeholder="Select a time" />
       </div>
+    </div>
+    <div class="form-row">
       <div class="form-cell">
         <label for="interest">What are you interested about?</label>
         <select id="interest" required>
@@ -75,6 +82,7 @@
           <option>Professionals</option>
         </select>
       </div>
+      <div class="form-cell"></div>
     </div>
     <div class="mt-1">
       <label for="comments">Comments</label>

--- a/css/center.css
+++ b/css/center.css
@@ -3,13 +3,9 @@
       font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
       margin: 0; padding: 20px;
       color: #222;
-      background: #ffffff;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
       transition: background 0.3s, color 0.3s;
-    }
-    body.dark {
-      background: #ffffff;
     }
     /* Navigation */
     nav {

--- a/css/contactus.css
+++ b/css/contactus.css
@@ -10,7 +10,6 @@
   }
   body {
     font-family: 'Segoe UI', Arial, sans-serif;
-    background: var(--clr-bg);
     color: var(--clr-tx);
     margin: 0; padding: 1rem;
     max-width: 600px;

--- a/css/it.css
+++ b/css/it.css
@@ -3,7 +3,6 @@
       font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
       margin: 0; padding: 20px;
       color: #222;
-      background: #f9f9fb;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
       transition: background 0.3s, color 0.3s;

--- a/css/joinus.css
+++ b/css/joinus.css
@@ -11,7 +11,6 @@
   }
   body {
     font-family: 'Segoe UI', Arial, sans-serif;
-    background: var(--clr-bg);
     color: var(--clr-tx);
     margin: 0; padding: 1rem;
     max-width: 600px;

--- a/css/pros.css
+++ b/css/pros.css
@@ -3,7 +3,6 @@
       font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
       margin: 0; padding: 20px;
       color: #222;
-      background: #f9f9fb;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
       transition: background 0.3s, color 0.3s;

--- a/join.html
+++ b/join.html
@@ -12,10 +12,11 @@
 <meta http-equiv="X-Frame-Options" content="SAMEORIGIN">
 <title>Join Us - OPS • Chattia</title>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" integrity="sha512-bNDdB2S/bRMyCV2wAPOQgpdnH3UX0DpD+s/COM24kTx5cDIeEJD7BqXc9EjoP6KDAdAm8YGtS+wGGyRyvCb4TQ==" crossorigin="anonymous" referrerpolicy="no-referrer">
-<link rel="stylesheet" href="css/style.css">
-<link rel="stylesheet" href="css/mobile-nav.css">
-<link rel="stylesheet" href="css/center.css">
-<link rel="stylesheet" href="css/joinus.css">
+  <link rel="stylesheet" href="css/style.css">
+  <link rel="stylesheet" href="css/shining-effect.css">
+  <link rel="stylesheet" href="css/mobile-nav.css">
+  <link rel="stylesheet" href="css/center.css">
+  <link rel="stylesheet" href="css/joinus.css">
 </head>
 <body>
 <nav class="ops-nav" aria-label="OPS Navigation">
@@ -41,18 +42,21 @@
   <form aria-label="Join us form" id="joinForm" autocomplete="off" novalidate action="#">
     <div class="form-pairs">
       <div>
-        <label for="name">Name</label>
-        <input id="name" name="name" required placeholder="Enter your name" />
+        <label for="name">Full Name</label>
+        <input id="name" name="name" required placeholder="" data-en="Full Name" data-es="Nombre Completo" />
       </div>
       <div>
-        <label for="email">Email</label>
-        <input id="email" type="email" name="email" required placeholder="Enter your email" />
+        <label for="email">Business Email</label>
+        <input id="email" type="email" name="email" required placeholder="" data-en="Business Email" data-es="Correo Electrónico Empresarial" />
       </div>
       <div>
-        <label for="phone">Phone</label>
-        <input id="phone" type="tel" name="phone" required placeholder="Enter your phone" />
+        <label for="phone">Your Phone Number</label>
+        <input id="phone" type="tel" name="phone" required placeholder="" data-en="Your Phone Number" data-es="Su Numero de Telefono" />
       </div>
-      <div></div>
+      <div>
+        <label for="company">Company</label>
+        <input id="company" type="text" name="company" required placeholder="" data-en="Company" data-es="Empresa" />
+      </div>
     </div>
     <div class="form-section" data-section="Skills">
       <div class="section-header">

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -70,6 +70,14 @@ function applyTranslations() {
     key.forEach(k => { if (text) text = text[k]; });
     if (text) el.setAttribute('alt', text);
   });
+  document.querySelectorAll('[data-en][data-es]').forEach(el => {
+    const text = lang === 'es' ? el.getAttribute('data-es') : el.getAttribute('data-en');
+    if (el.hasAttribute('placeholder')) {
+      el.setAttribute('placeholder', text);
+    } else {
+      el.textContent = text;
+    }
+  });
   if (typeof renderCards === 'function') renderCards();
 }
 function switchLanguage(l) {

--- a/mainnav/center.html
+++ b/mainnav/center.html
@@ -33,6 +33,7 @@
 <!-- Remove referrer info for outbound links (privacy) -->
 <meta name="referrer" content="no-referrer">
   <link rel="stylesheet" href="../css/style.css">
+  <link rel="stylesheet" href="../css/shining-effect.css">
   <link rel="stylesheet" href="../css/mobile-nav.css">
   <link rel="stylesheet" href="../css/center.css">
   <link rel="stylesheet" href="../css/z-layout.css">
@@ -121,24 +122,10 @@
     <h2 id="center-form-title" data-i18n="form.contactTitle">See What We Can Do for You</h2>
     <!-- Form submission handled via JavaScript -->
     <form aria-labelledby="center-form-title" action="#">
-      <input
-        type="text" aria-label="Full Name"
-        placeholder="Full Name"
-        data-i18n-ph="form.fullName"
-        required
-      />
-      <input
-        type="email" aria-label="Business Email"
-        placeholder="Business Email"
-        data-i18n-ph="form.businessEmail"
-        required
-      />
-      <input
-        type="text" aria-label="Company"
-        placeholder="Company"
-        data-i18n-ph="form.company"
-        required
-      />
+      <input type="text" aria-label="Full Name" placeholder="" data-en="Full Name" data-es="Nombre Completo" required />
+      <input type="email" aria-label="Business Email" placeholder="" data-en="Business Email" data-es="Correo Electrónico Empresarial" required />
+      <input type="tel" aria-label="Your Phone Number" placeholder="" data-en="Your Phone Number" data-es="Su Numero de Telefono" required />
+      <input type="text" aria-label="Company" placeholder="" data-en="Company" data-es="Empresa" required />
       <button type="submit" data-i18n="form.requestQuote">Request Quote</button>
     </form>
   </section>

--- a/mainnav/it.html
+++ b/mainnav/it.html
@@ -33,6 +33,7 @@
 <!-- Remove referrer info for outbound links (privacy) -->
 <meta name="referrer" content="no-referrer">
   <link rel="stylesheet" href="../css/style.css">
+  <link rel="stylesheet" href="../css/shining-effect.css">
   <link rel="stylesheet" href="../css/mobile-nav.css">
   <link rel="stylesheet" href="../css/it.css">
 </head>
@@ -86,24 +87,10 @@
     <h2 id="it-form-title" data-i18n="form.contactTitle">See What We Can Do for You</h2>
     <!-- Form submission handled via JavaScript -->
     <form aria-labelledby="it-form-title" action="#">
-      <input
-        type="text" aria-label="Full Name"
-        placeholder="Full Name"
-        data-i18n-ph="form.fullName"
-        required
-      />
-      <input
-        type="email" aria-label="Business Email"
-        placeholder="Business Email"
-        data-i18n-ph="form.businessEmail"
-        required
-      />
-      <input
-        type="text" aria-label="Company"
-        placeholder="Company"
-        data-i18n-ph="form.company"
-        required
-      />
+      <input type="text" aria-label="Full Name" placeholder="" data-en="Full Name" data-es="Nombre Completo" required />
+      <input type="email" aria-label="Business Email" placeholder="" data-en="Business Email" data-es="Correo Electrónico Empresarial" required />
+      <input type="tel" aria-label="Your Phone Number" placeholder="" data-en="Your Phone Number" data-es="Su Numero de Telefono" required />
+      <input type="text" aria-label="Company" placeholder="" data-en="Company" data-es="Empresa" required />
       <button type="submit" data-i18n="form.requestQuote">Request Quote</button>
     </form>
   </section>

--- a/mainnav/opera.html
+++ b/mainnav/opera.html
@@ -33,6 +33,7 @@
 <!-- Remove referrer info for outbound links (privacy) -->
 <meta name="referrer" content="no-referrer">
   <link rel="stylesheet" href="../css/style.css">
+  <link rel="stylesheet" href="../css/shining-effect.css">
   <link rel="stylesheet" href="../css/mobile-nav.css">
   <link rel="stylesheet" href="../css/opera.css">
 </head>
@@ -99,24 +100,10 @@
     <h2 id="opera-form-title" data-i18n="form.contactTitle">See What We Can Do for You</h2>
     <!-- Form submission handled via JavaScript -->
     <form aria-labelledby="opera-form-title" action="#">
-      <input
-        type="text" aria-label="Full Name"
-        placeholder="Full Name"
-        data-i18n-ph="form.fullName"
-        required
-      />
-      <input
-        type="email" aria-label="Business Email"
-        placeholder="Business Email"
-        data-i18n-ph="form.businessEmail"
-        required
-      />
-      <input
-        type="text" aria-label="Company"
-        placeholder="Company"
-        data-i18n-ph="form.company"
-        required
-      />
+      <input type="text" aria-label="Full Name" placeholder="" data-en="Full Name" data-es="Nombre Completo" required />
+      <input type="email" aria-label="Business Email" placeholder="" data-en="Business Email" data-es="Correo Electrónico Empresarial" required />
+      <input type="tel" aria-label="Your Phone Number" placeholder="" data-en="Your Phone Number" data-es="Su Numero de Telefono" required />
+      <input type="text" aria-label="Company" placeholder="" data-en="Company" data-es="Empresa" required />
       <button type="submit" data-i18n="form.requestQuote">Request Quote</button>
     </form>
   </section>

--- a/mainnav/pros.html
+++ b/mainnav/pros.html
@@ -33,6 +33,7 @@
 <!-- Remove referrer info for outbound links (privacy) -->
 <meta name="referrer" content="no-referrer">
   <link rel="stylesheet" href="../css/style.css">
+  <link rel="stylesheet" href="../css/shining-effect.css">
   <link rel="stylesheet" href="../css/mobile-nav.css">
   <link rel="stylesheet" href="../css/pros.css">
 </head>
@@ -100,24 +101,10 @@
     <h2 id="pros-form-title" data-i18n="form.contactTitle">See What We Can Do for You</h2>
     <!-- Form submission handled via JavaScript -->
     <form aria-labelledby="pros-form-title" action="#">
-      <input
-        type="text" aria-label="Full Name"
-        placeholder="Full Name"
-        data-i18n-ph="form.fullName"
-        required
-      />
-      <input
-        type="email" aria-label="Business Email"
-        placeholder="Business Email"
-        data-i18n-ph="form.businessEmail"
-        required
-      />
-      <input
-        type="text" aria-label="Company"
-        placeholder="Company"
-        data-i18n-ph="form.company"
-        required
-      />
+      <input type="text" aria-label="Full Name" placeholder="" data-en="Full Name" data-es="Nombre Completo" required />
+      <input type="email" aria-label="Business Email" placeholder="" data-en="Business Email" data-es="Correo Electrónico Empresarial" required />
+      <input type="tel" aria-label="Your Phone Number" placeholder="" data-en="Your Phone Number" data-es="Su Numero de Telefono" required />
+      <input type="text" aria-label="Company" placeholder="" data-en="Company" data-es="Empresa" required />
       <button type="submit" data-i18n="form.requestQuote">Request Quote</button>
     </form>
   </section>

--- a/service.html
+++ b/service.html
@@ -13,6 +13,7 @@
 <title>Service Details - OPS</title>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" integrity="sha512-RXf+QSDCUqpphKAa+WAc3XQ8fE5H1aO/8e2wY+8Q1n8yVwDh1RZTf1TDN8E+u1n7eU5KyY7X2Qo+hqeZZn+UAQ==" crossorigin="anonymous" referrerpolicy="no-referrer">
 <link rel="stylesheet" href="css/style.css">
+<link rel="stylesheet" href="css/shining-effect.css">
 <link rel="stylesheet" href="css/mobile-nav.css">
 <link rel="stylesheet" href="css/center.css">
 <link rel="stylesheet" href="css/service.css">


### PR DESCRIPTION
## Summary
- Standardize contact forms across pages with bilingual placeholders and phone field
- Enable dynamic placeholder translations via data-en/data-es attributes
- Apply landing page gradient and transition effects site-wide

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e9c21cf68832b940605e3776fbb7e