### PR TITLE
Center main navigation page content

### DIFF
--- a/mainnav/center.html
+++ b/mainnav/center.html
@@ -38,7 +38,7 @@
   <link rel="stylesheet" href="../css/center.css">
   <link rel="stylesheet" href="../css/z-layout.css">
 </head>
-<body>
+<body style="text-align: center;">
   <!-- Navigation Menu -->
   <nav class="ops-nav" aria-label="OPS Navigation">
     <span class="ops-logo">OPS</span>

--- a/mainnav/it.html
+++ b/mainnav/it.html
@@ -37,7 +37,7 @@
   <link rel="stylesheet" href="../css/mobile-nav.css">
   <link rel="stylesheet" href="../css/it.css">
 </head>
-<body>
+<body style="text-align: center;">
  <!-- Navigation Menu -->
   <nav class="ops-nav" aria-label="OPS Navigation">
     <span class="ops-logo">OPS</span>

--- a/mainnav/opera.html
+++ b/mainnav/opera.html
@@ -37,7 +37,7 @@
   <link rel="stylesheet" href="../css/mobile-nav.css">
   <link rel="stylesheet" href="../css/opera.css">
 </head>
-<body>
+<body style="text-align: center;">
   <!-- Navigation Menu -->
   <nav class="ops-nav" aria-label="OPS Navigation">
     <span class="ops-logo">OPS</span>

--- a/mainnav/pros.html
+++ b/mainnav/pros.html
@@ -37,7 +37,7 @@
   <link rel="stylesheet" href="../css/mobile-nav.css">
   <link rel="stylesheet" href="../css/pros.css">
 </head>
-<body>
+<body style="text-align: center;">
   <!-- Navigation Menu -->
   <nav class="ops-nav" aria-label="OPS Navigation">
     <span class="ops-logo">OPS</span>


### PR DESCRIPTION
## Summary
- Centered content across Business Operations, Contact Center, IT Support, and Professionals pages by applying `text-align: center` on the `<body>` element.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ecae2ceec832b856c8ff991f87d00